### PR TITLE
Add more labels

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -191,15 +191,12 @@ Useful when using [Custom rsync Arugments](#custom-rsync-arguments)
 USE_DEFAULT_RSYNC_ARGS=false
 ```
 
+<small>🔄 This is the same action as the [Use Default rsync Arguments](./labels.md#use-default-rsync-arguments) label, but applied globally.</small>
+
 ## Custom rsync Arguments
 Apply custom `rsync` args <small>(in addition to the [default](#use-default-rsync-arguments) args)</small>
 
 > **Default**: *empty* <small>(no custom rsync args will be applied)</small>
-
-The `RSYNC_CUSTOM_ARGS` will be inserted after the `$DEFAULT_RSYNC_ARGS` as shown:
-```bash
-rsync $DEFAULT_RSYNC_ARGS $RSYNC_CUSTOM_ARGS $src_dir/ $dest_dir/
-```
 
 There are many `rsync` arguments and customizations that be be used here.
 
@@ -209,5 +206,13 @@ There are many `rsync` arguments and customizations that be be used here.
     RSYNC_CUSTOM_ARGS=--exclude='*.log' --exclude='*.txt'
     ```
 
+The `RSYNC_CUSTOM_ARGS` will be inserted after the `$DEFAULT_RSYNC_ARGS` as shown:
+```bash
+rsync $DEFAULT_RSYNC_ARGS $RSYNC_CUSTOM_ARGS $src_dir/ $dest_dir/
+```
+
+
+
+<small>🔄 This is the same action as the [Custom rsync Arguments](./labels.md#custom-rsync-arguments) label, but applied globally.</small>
 <br>
 <br>

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -128,7 +128,7 @@ nautical-backup.enable=true
 
 With this label set to `false`, the container will not be stopped before performing a backup.
 
-> **Default If Missing**: true <small> (container ==will== be stopped before backup).</small>
+> **Default If Missing**: true <small> (container ^^will^^ be stopped before backup).</small>
 
 ```properties
 nautical-backup.stop-before-backup=false
@@ -174,3 +174,37 @@ nautical-backup.override-destination-dir=new_folder_name
 ```
 
 <small>🔄 This is the same action as the [Override Destination Directory](./arguments.md#override-destination-directory) variable, but applied only to this container.</small>
+
+## Use Default rsync Arguments
+Use the default `rsync` arguemnts `-raq` <small>(recursive, archive, quiet)</small>
+
+Useful when using [Custom rsync Arugments](#custom-rsync-arguments)
+
+> **Default**: *none* <small>(use global setting)</small>
+
+```properties
+nautical-backup.use-default-rsync-args=false
+```
+
+!!! note "This label will *override* the global setting applied through [Enviornment Variables](./arguments.md)"
+    * A value of `true` will use the default rsync arguments regardless of the global setting.
+    * A value of `false` will ^^**not**^^ use the default rsync arguments regardless of the global setting.
+    * Not setting the label value will use the [global setting](./arguments.md#custom-rsync-arguments)
+
+<small>🔄 Not setting a label is the same action as the [Use Default rsync Arguments](./arguments.md#use-default-rsync-arguments) variable, but applied only to this container.</small>
+
+## Custom rsync Arguments
+Apply custom `rsync` args <small>(in addition to the [default](#use-default-rsync-arguments) args)</small>
+
+> **Default**: *empty* <small>(use global setting)</small>
+
+```properties
+nautical-backup.rsync-custom-args=--exclude='*.log' --exclude='*.txt'
+```
+
+!!! note "This label will *override* the global setting applied through [Enviornment Variables](./arguments.md)"
+    * *Any value* will override the global rsync arguemnts configured through [global settings](./arguments.md#custom-rsync-arguments).
+    * A <small>(empty)</small> value of  `"nautical-backup.rsync-custom-args="` will ^^cancel^^ any [global setting](./arguments.md#custom-rsync-arguments) for this container only.
+    * Not setting the label value will use the [global setting](./arguments.md#custom-rsync-arguments).
+
+<small>🔄 Not setting a label is the same action as the [Custom rsync Arguments](./arguments.md#custom-rsync-arguments) variable, but applied only to this container.</small>

--- a/pkg/backup.sh
+++ b/pkg/backup.sh
@@ -53,6 +53,7 @@ if [ "$REPORT_FILE" = "true" ]; then
     echo "Backup Report - $(date)" >"$DEST_LOCATION/$report_file"
 fi
 
+DEFAULT_RSYNC_ARGS="-ahq"
 default_rsync_args="-ahq"
 if [ "$USE_DEFAULT_RSYNC_ARGS" = "false" ]; then
     default_rsync_args=""
@@ -140,6 +141,20 @@ BackupContainer() {
                 log_entry "Error stopping container $container. Skipping backup for this container."
                 return
             fi
+        fi
+
+        if echo "$labels" | grep -q '"nautical-backup.use-default-rsync-args":"true"'; then
+            echo "Using default rsync args ($DEFAULT_RSYNC_ARGS) for $container"
+            default_rsync_args=$DEFAULT_RSYNC_ARGS
+        elif echo "$labels" | grep -q '"nautical-backup.use-default-rsync-args":"false"'; then
+            echo "Not using default rsync args ($DEFAULT_RSYNC_ARGS) for $container"
+            default_rsync_args=""
+        fi
+
+        if echo "$labels" | grep -q '"nautical-backup.rsync-custom-args"'; then
+            new_custom_rsync_args=$(echo "$labels" | jq -r '.["nautical-backup.rsync-custom-args"]')
+            custom_args=$new_custom_rsync_args
+            echo "Using custom rsync args for $container"
         fi
 
         log_entry "Backing up $container data..."


### PR DESCRIPTION
Added 2 additional Docker Labels that can be used:

1. `nautical-backup.use-default-rsync-args`
2. `nautical-backup.rsync-custom-args`
