### PR TITLE
Add EXIT_AFTER_INIT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,5 +74,8 @@ ENV REPORT_FILE_ON_BACKUP_ONLY="true"
 # When true, and an source dir override is applied, then the destination directory will be same same as the new source directory 
 ENV KEEP_SRC_DIR_NAME="true"
 
+# Usually combined with BACKUP_ON_START. Essentially, this just exists the container after 1 run.
+ENV EXIT_AFTER_INIT="false"
+
 # Run the entry script and pass all variables to it
 ENTRYPOINT [ "bash", "-c", "exec ./entry.sh \"${@}\"", "--"]

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -1,10 +1,10 @@
-Nautical provides configuration in the form of Docker enviornment variables.
+Nautical provides configuration in the form of Docker environment variables.
 
-See the [Installation Section](./installation.md), which contains a few examples of applying enviornment variables.
+See the [Installation Section](./installation.md), which contains a few examples of applying environment variables.
 
-### Enviornment Variable vs Label Priority
-If a container has an Enviornment Variable applied as well as a conflicting Label, then:
-> The continer Label takes priority over the global Natical enviornment variable.
+### Environment Variable vs Label Priority
+If a container has an Environment Variable applied as well as a conflicting Label, then:
+> The continer Label takes priority over the global Natical environment variable.
 
 ## Time Zone
 
@@ -165,6 +165,17 @@ Will immediatly perform a backup when the container is started in addition to th
 BACKUP_ON_START=true
 ```
 
+## Exit Nautical after Initialization
+Usually combined with [Backup on Start](#backup-on-start); this variable will tell Nautical to immediately quit after initialization.
+
+> **Default**: false
+
+```properties
+EXIT_AFTER_INIT=true
+```
+
+With [Backup on Start](#backup-on-start) and [Exit Nautical after Initialization](#exit-nautical-after-initialization) both set to `true`, 
+then Nautical will perform 1 backup and then quit--regardless of the [CRON Schedule](#cron-schedule) <small>(All other [variables](./arguments.md) and [labels](./labels.md) still apply)</small>.
 
 ## Mirror Source Directory Name to Destination
 Mirror the source folder name to the destination folder name. By default <small>(without any [overrides](#override-source-directory))</small>, this means both the `source` and `destination` folder names are the ^^same as the container name^^.
@@ -204,7 +215,7 @@ Only used if the repot file is [enabled](#report-file).
 REPORT_FILE_LOG_LEVEL=INFO
 ```
 
-## Use report file on backup only
+## Use Report File on Backup Only
 With a value of `true`, then the report file will only be created when a backup is performed, not during Nautical initialization.
 
 With a value of `false`, then all logs will also be sent to the report file assuming they are the right [log level](#report-log-level).

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -1,4 +1,4 @@
-Docker Labels allow us to apply settings to Nautical on a per-container basis. Instead of applying [enviornment variables](./arguments.md), we can apply the label to the each container seperately.
+Docker Labels allow us to apply settings to Nautical on a per-container basis. Instead of applying [environment variables](./arguments.md), we can apply the label to the each container seperately.
 
 ### How to add labels
 
@@ -57,15 +57,15 @@ Remember, these labels can be added to any container <small> (other than Nautica
       pihole/pihole:latest
     ```
 
-### Label vs Enviornment Variable Priority
-If a container has an Enviornment Variable applied as well as a conflicting Label, then:
-> The continer Label takes priority over the global Natical enviornment variable.
+### Label vs Environment Variable Priority
+If a container has an Environment Variable applied as well as a conflicting Label, then:
+> The continer Label takes priority over the global Natical environment variable.
 
 ## Enable or Disable Nautical
 This Docker label can be used to acheive 2 things:
 
 1. Opt a container **OUT** of backup
-1. Opt a container **IN** to a backup <small>(with the Nautical [Require Label](./arguments.md#require-label) enviornment variable set to `true`)</small>
+1. Opt a container **IN** to a backup <small>(with the Nautical [Require Label](./arguments.md#require-label) environment variable set to `true`)</small>
 
 > **Default If Missing**: true <small> (all containers will be enabled, unless [Require Label](./arguments.md#require-label) is set to `true`).</small>
 
@@ -95,11 +95,11 @@ nautical-backup.enable=true
         - [ ] Service 1 - *Skipped* since `nautical-backup.enable` was set to `false`
         - [x] Service 2 - *Backed up* since the label `nautical-backup.enable=true` was present
         - [x] Service 3 - *Backed up* since no `nautical-backup.enable=false` label was found
-            - The [Require Label](./arguments.md#require-label) enviornment variable was either *not set* or set to `false` for this example
+            - The [Require Label](./arguments.md#require-label) environment variable was either *not set* or set to `false` for this example
 
 
 === "Example 2 (Opt in)"
-    !!! note " With [Require Label](./arguments.md#require-label) enviornment variable set to `true`"
+    !!! note " With [Require Label](./arguments.md#require-label) environment variable set to `true`"
         ```yaml title=""
         services: # Example Service #1 config ...
           labels:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,7 +35,7 @@ nav:
  - Home: index.md
  - Introduction: introduction.md
  - Installation: installation.md
- - Variables: arguments.md
+ - Environment Variables: arguments.md
  - Docker Labels: labels.md
  - Updating Nautical: updates.md
  - Advanced Usage: 

--- a/pkg/entry.sh
+++ b/pkg/entry.sh
@@ -150,6 +150,11 @@ if [ "$BACKUP_ON_START" = "true" ]; then
     bash ./app/backup.sh
 fi
 
+if [ "$EXIT_AFTER_INIT" = "true" ]; then
+    logThis "EXIT_AFTER_INIT: $EXIT_AFTER_INIT" "DEBUG" "init"
+    exit 0
+fi
+
 logThis "Initialization complete. Awaiting CRON schedule: $CRON_SCHEDULE" "INFO" "init"
 
 # Start cron and keep container running


### PR DESCRIPTION
## Exit Nautical after Initialization
Usually combined with `Backup on Start`; this variable will tell Nautical to immediately quit after initialization.

> **Default**: false

```properties
EXIT_AFTER_INIT=true
```

With `Backup on Start` and `Exit Nautical after Initialization` both set to `true`, 
then Nautical will perform 1 backup and then quit--regardless of the `CRON Schedule` <small>(All other 
variables and labels still apply)</small>.
