### PR TITLE
Update S6 Version and Renovate Bot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -41,12 +41,13 @@
         "README.md"
       ],
       "automerge": true,
+      "rangeStrategy": "bump",
       "labels": ["documentation"],
       "assignees": ["minituff"],
       "ignoreTests": true
     },
     {
-      "description": "Dockerfile depedencies",
+      "description": "Dockerfile dependencies",
       "matchDatasources": ["docker"],
       "matchFileNames": [
         "Dockerfile"
@@ -54,6 +55,26 @@
       "labels": ["depedency"],
       "assignees": ["minituff"],
       "automerge": true,
+      "rangeStrategy": "bump",
+      "ignoreTests": false,
+      "schedule": ["at any time"],
+      "minimumReleaseAge": "2 days",
+      "commitBody": "[bump version]",
+      "extends": [
+        "default:automergeDigest",
+        "default:automergeBranchPush"
+      ]
+    },
+    {
+      "description": "Python dependencies",
+      "matchDatasources": ["pypi"],
+      "matchFileNames": [
+        "**/requirements.txt"
+      ],
+      "labels": ["depedency"],
+      "assignees": ["minituff"],
+      "automerge": true,
+      "rangeStrategy": "bump",
       "ignoreTests": false,
       "schedule": ["at any time"],
       "minimumReleaseAge": "2 days",

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ LABEL maintainer="minituff"
 ARG TEST_MODE="-1"
 
 # renovate: datasource=github-releases depName=just-containers/s6-overlay versioning=loose
-ENV S6_OVERLAY_VERSION="3.1.6.0"
+ENV S6_OVERLAY_VERSION="3.1.6.2"
 
 
 # Install S6 Overlay

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,7 +1,7 @@
-fastapi==0.104.*
-pydantic==2.5.*
-uvicorn==0.24.*
-croniter==2.0.*
-pytz==2023.*
-docker==6.1.*
-pydantic-settings==2.1.*
+fastapi==0.104.1
+pydantic==2.5.2
+uvicorn==0.24.0.post1
+croniter==2.0.1
+pytz==2023.3.post1
+docker==6.1.3
+pydantic-settings==2.1.0


### PR DESCRIPTION
* Update S6-overlay [3.1.6.2](https://github.com/just-containers/s6-overlay/releases/tag/v3.1.6.2). This includes
  * Fixed but that caused containers to hang on shutdown. 
  * This is a bugfix release, updating to the latest versions of the skarnet.org packages. It fixes a bug where services declared in `/etc/services.d` were not properly killed during the regular shutdown procedure and were only caught by the final timeout.
* Update Renovate Bot to auto-bump and release Nautical updates based on Pip versions.