### PR TITLE
Fix backup when ADDITIONAL_FOLDERS_WHEN="after"

### DIFF
--- a/pkg/backup.sh
+++ b/pkg/backup.sh
@@ -344,8 +344,8 @@ db put "containers_skipped" "$containers_skipped"
 
 logThis "Success. $containers_completed containers backed up! $containers_skipped skipped." "INFO"
 
-if [ "$ADDITIONAL_FOLDERS_WHEN" = "after" ]; then
-    BackupAdditionalFolders $ADDITIONAL_FOLDERS_LIST_STR $default_rsync_args $custom_args
+if [ "$ADDITIONAL_FOLDERS_WHEN" = "after" ] && [ ! -z "$ADDITIONAL_FOLDERS" ]; then
+    BackupAdditionalFolders "$ADDITIONAL_FOLDERS" "$default_rsync_args" "$custom_args"
 fi
 
 if [ ! -z "$POST_BACKUP_CURL" ]; then


### PR DESCRIPTION
Thank you to @jpdsc in https://github.com/Minituff/nautical-backup/issues/141 for discovering that when the Environment variable `ADDITIONAL_FOLDERS_WHEN="after"` is set, the backup for the additional folder will not work. This PR will fix that.