### PR TITLE
Add Kickoff API endpoint

### DIFF
--- a/app/api/nautical_router.py
+++ b/app/api/nautical_router.py
@@ -1,5 +1,5 @@
 from typing import Any, Union, Optional
-from fastapi import HTTPException, APIRouter, Depends, Path, status
+from fastapi import HTTPException, APIRouter, Depends, Path, status, BackgroundTasks
 import subprocess
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
@@ -13,6 +13,14 @@ from app.db import DB
 router = APIRouter(prefix="/api/v1/nautical", tags=["nautical"])
 
 db = DB()
+
+
+def kickoff_nautical():
+    try:
+        subprocess.run(["nautical"], check=True)
+        return {"message": f"Nautical Backup completed successfully"}
+    except subprocess.CalledProcessError as e:
+        raise HTTPException(status_code=500, detail=str(e.stderr.decode()))
 
 
 @router.get("/dashboard", summary="The most useful information", response_class=JSONResponse)
@@ -50,13 +58,28 @@ def next_cron(
     return res
 
 
-@router.post("/start_backup", summary="Start backup now", response_class=JSONResponse)
+@router.post(
+    "/start_backup",
+    summary="Start backup now, will not respond until the backup has been completed.",
+    response_class=JSONResponse,
+)
 def start_backup(username: Annotated[str, Depends(authorize)]):
     """
-    Start a backup now. This respects all environment and docker labels.
+    Start a backup now and respond when completed. This respects all environment and docker labels.
     """
-    try:
-        subprocess.run(["nautical"], check=True)
-        return {"message": f"Nautical Backup started successfully"}
-    except subprocess.CalledProcessError as e:
-        raise HTTPException(status_code=500, detail=str(e.stderr.decode()))
+    return kickoff_nautical()
+
+
+@router.post(
+    "/kickoff_backup",
+    summary="Start backup now, will immediatly respond even though the backup continues in the background",
+    response_class=JSONResponse,
+)
+async def kickoff_backup(username: Annotated[str, Depends(authorize)], background_tasks: BackgroundTasks):
+    """
+    Start a backup now and respond immediately. This respects all environment and docker labels.
+    """
+    # Run the func 'kickoff_nautical' in the background, but return immediately
+    background_tasks.add_task(kickoff_nautical)
+
+    return {"message": f"Nautical Backup started successfully"}

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -112,7 +112,25 @@ Get the next *n* scheduled times Nautical will run.
 > POST
 > /api/v1/nautical/start_backup
 
-Start a backup now. All the [Variables](./arguments.md) and [Labels](./labels.md) are respected.
+Start a backup now. The API will not respond until the backup has completed. 
+
+All the [Variables](./arguments.md) and [Labels](./labels.md) are respected.
+
+???+ example "Example response"
+    ```json
+    {
+      "message": "Nautical Backup completed successfully"
+    }
+    ```
+
+## Kickoff Backup
+
+> POST
+> /api/v1/nautical/kickoff_backup
+
+Start a backup now in the background. The API will respond immediately.
+
+All the [Variables](./arguments.md) and [Labels](./labels.md) are respected.
 
 ???+ example "Example response"
     ```json


### PR DESCRIPTION
## Kickoff Backup

> POST
> /api/v1/nautical/kickoff_backup

Start a backup now in the background. The API will respond immediately.

All the [Variables](./arguments.md) and [Labels](./labels.md) are respected.

### Example response
  ```json
  {
    "message": "Nautical Backup started successfully"
  }
  ```