### PR TITLE
Create dated destination folder

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.3.0
+    rev: 24.4.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ ENV PYTHON_VERSION="3.11.8-r0"
 # renovate: datasource=repology depName=alpine_3_18/py3-pip versioning=loose
 ENV PIP_VERSION="23.1.2-r0"
 # renovate: datasource=repology depName=alpine_3_18/ruby-full versioning=loose
-ENV RUBY_VERSION="3.2.2-r0"
+ENV RUBY_VERSION="3.2.4-r0"
 
 # Hide the S6 init logs. 2 = start and stop operations, 1 = warnings and errors, 0 = errors. Default 2: Options 0-5
 ENV S6_VERBOSITY=1

--- a/app/backup.py
+++ b/app/backup.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python3
 
 import os
-from datetime import datetime
-from typing import Dict, List, Optional, Tuple, Union
-import sys
 import subprocess
-from pathlib import Path
+import sys
+import time
+from datetime import datetime
 from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
 
 import docker
-from docker.models.containers import Container
 from docker.errors import APIError
+from docker.models.containers import Container
 
-from app.db import DB
 from app.api.config import Settings
+from app.db import DB
 from app.logger import Logger, LogType
 from app.nautical_env import NauticalEnv
 
@@ -355,6 +356,11 @@ class NauticalBackup:
         if label_dest and label_dest != "":
             self.log_this(f"Overriding destination directory for {c.name} to '{label_dest}' from label")
             dest_dir = base_dest_dir / label_dest
+
+        if str(self.env.USE_DEST_DATE_FOLDER).lower() == "true":
+            dest_dir: Path = base_dest_dir / str(c.name) / str(time.strftime("%Y-%m-%d"))
+            if not os.path.exists(dest_dir):
+                os.makedirs(dest_dir)
 
         return dest_dir
 

--- a/app/backup.py
+++ b/app/backup.py
@@ -359,7 +359,7 @@ class NauticalBackup:
 
         if str(self.env.USE_DEST_DATE_FOLDER).lower() == "true":
             # Final name of the actual folder
-            time_format = time.strftime(self.env.DEST_DATE_FORMAT)
+            time_format = str(time.strftime(self.env.DEST_DATE_FORMAT))
 
             if str(self.env.DEST_DATE_PATH_FORMAT) == "container/date":
                 dest_dir: Path = base_dest_dir / str(c.name) / time_format

--- a/app/backup.py
+++ b/app/backup.py
@@ -368,7 +368,18 @@ class NauticalBackup:
                 )
                 self.log_this(f"{e}", "ERROR")
                 time_format = time.strftime("%Y-%m-%d")
-            dest_dir: Path = base_dest_dir / str(c.name) / str(time_format)
+
+            if str(self.env.DEST_DATE_PATH_FORMAT) == "container/date":
+                dest_dir: Path = base_dest_dir / str(c.name) / str(time_format)
+            elif str(self.env.DEST_DATE_PATH_FORMAT) == "date/container":
+                dest_dir: Path = base_dest_dir / str(time_format) / str(c.name)
+            else:
+                self.log_this(
+                    f"Invalid DEST_DATE_PATH_FORMAT: {str(self.env.DEST_DATE_PATH_FORMAT)}. Using default format.",
+                    "ERROR",
+                )
+                dest_dir: Path = base_dest_dir / str(time_format) / str(c.name)
+
             if not os.path.exists(dest_dir):
                 os.makedirs(dest_dir)
 

--- a/app/backup.py
+++ b/app/backup.py
@@ -358,14 +358,13 @@ class NauticalBackup:
             dest_dir = base_dest_dir / label_dest
 
         if str(self.env.USE_DEST_DATE_FOLDER).lower() == "true":
-            time_format = time.strftime(str(self.env.DEST_DATE_FORMAT))
             # Final name of the actual folder
-            dest_date_folder = f"{str(time_format)}"
+            time_format = time.strftime(self.env.DEST_DATE_FORMAT)
 
             if str(self.env.DEST_DATE_PATH_FORMAT) == "container/date":
-                dest_dir: Path = base_dest_dir / str(c.name) / dest_date_folder
+                dest_dir: Path = base_dest_dir / str(c.name) / time_format
             elif str(self.env.DEST_DATE_PATH_FORMAT) == "date/container":
-                dest_dir: Path = base_dest_dir / dest_date_folder / str(c.name)
+                dest_dir: Path = base_dest_dir / time_format / str(c.name)
 
             if not os.path.exists(dest_dir):
                 os.makedirs(dest_dir, exist_ok=True)

--- a/app/backup.py
+++ b/app/backup.py
@@ -358,29 +358,13 @@ class NauticalBackup:
             dest_dir = base_dest_dir / label_dest
 
         if str(self.env.USE_DEST_DATE_FOLDER).lower() == "true":
-            try:
-                time_format = time.strftime(str(self.env.DEST_DATE_FORMAT))
-            # TODO: use exact exception
-            except Exception as e:
-                self.log_this(
-                    f"Error formatting date: {str(self.env.DEST_DATE_FORMAT)} is not a valid time format. Using default format.{e}",
-                    "ERROR",
-                )
-                self.log_this(f"{e}", "ERROR")
-                time_format = time.strftime("%Y-%m-%d")
-
+            time_format = time.strftime(str(self.env.DEST_DATE_FORMAT))
             # Final name of the actual folder
-            dest_date_folder = f"{self.env.DEST_DATE_PATH_PREFIX}{str(time_format)}{self.env.DEST_DATE_PATH_SUFFIX}"
+            dest_date_folder = f"{str(time_format)}"
 
             if str(self.env.DEST_DATE_PATH_FORMAT) == "container/date":
                 dest_dir: Path = base_dest_dir / str(c.name) / dest_date_folder
             elif str(self.env.DEST_DATE_PATH_FORMAT) == "date/container":
-                dest_dir: Path = base_dest_dir / dest_date_folder / str(c.name)
-            else:
-                self.log_this(
-                    f"Invalid DEST_DATE_PATH_FORMAT: {str(self.env.DEST_DATE_PATH_FORMAT)}. Using default format.",
-                    "ERROR",
-                )
                 dest_dir: Path = base_dest_dir / dest_date_folder / str(c.name)
 
             if not os.path.exists(dest_dir):

--- a/app/backup.py
+++ b/app/backup.py
@@ -358,7 +358,17 @@ class NauticalBackup:
             dest_dir = base_dest_dir / label_dest
 
         if str(self.env.USE_DEST_DATE_FOLDER).lower() == "true":
-            dest_dir: Path = base_dest_dir / str(c.name) / str(time.strftime("%Y-%m-%d"))
+            try:
+                time_format = time.strftime(str(self.env.DEST_DATE_FORMAT))
+            # TODO: use exact exception
+            except Exception as e:
+                self.log_this(
+                    f"Error formatting date: {str(self.env.DEST_DATE_FORMAT)} is not a valid time format. Using default format.{e}",
+                    "ERROR",
+                )
+                self.log_this(f"{e}", "ERROR")
+                time_format = time.strftime("%Y-%m-%d")
+            dest_dir: Path = base_dest_dir / str(c.name) / str(time_format)
             if not os.path.exists(dest_dir):
                 os.makedirs(dest_dir)
 

--- a/app/backup.py
+++ b/app/backup.py
@@ -369,19 +369,22 @@ class NauticalBackup:
                 self.log_this(f"{e}", "ERROR")
                 time_format = time.strftime("%Y-%m-%d")
 
+            # Final name of the actual folder
+            dest_date_folder = f"{self.env.DEST_DATE_PATH_PREFIX}{str(time_format)}{self.env.DEST_DATE_PATH_SUFFIX}"
+
             if str(self.env.DEST_DATE_PATH_FORMAT) == "container/date":
-                dest_dir: Path = base_dest_dir / str(c.name) / str(time_format)
+                dest_dir: Path = base_dest_dir / str(c.name) / dest_date_folder
             elif str(self.env.DEST_DATE_PATH_FORMAT) == "date/container":
-                dest_dir: Path = base_dest_dir / str(time_format) / str(c.name)
+                dest_dir: Path = base_dest_dir / dest_date_folder / str(c.name)
             else:
                 self.log_this(
                     f"Invalid DEST_DATE_PATH_FORMAT: {str(self.env.DEST_DATE_PATH_FORMAT)}. Using default format.",
                     "ERROR",
                 )
-                dest_dir: Path = base_dest_dir / str(time_format) / str(c.name)
+                dest_dir: Path = base_dest_dir / dest_date_folder / str(c.name)
 
             if not os.path.exists(dest_dir):
-                os.makedirs(dest_dir)
+                os.makedirs(dest_dir, exist_ok=True)
 
         return dest_dir
 

--- a/app/defaults.env
+++ b/app/defaults.env
@@ -15,10 +15,10 @@ BACKUP_ON_START=false
 USE_DEST_DATE_FOLDER=false
 
 # Options are "container/date" or "date/container"
-DEST_DATE_PATH_FORMAT="date/container"
+DEST_DATE_PATH_FORMAT=date/container
 
 # Python Date format
-DEST_DATE_FORMAT="%Y-%m-%d"
+DEST_DATE_FORMAT=%Y-%m-%d
 
 # Use the default rsync args "-ahq" (archive, human-readable, quiet)
 USE_DEFAULT_RSYNC_ARGS=true

--- a/app/defaults.env
+++ b/app/defaults.env
@@ -14,6 +14,9 @@ BACKUP_ON_START=false
 # Create a new folder on each backup
 USE_DEST_DATE_FOLDER=false
 
+# Options are "container/date" or "date/container"
+DEST_DATE_PATH_FORMAT="date/container"
+
 # Python Date format
 DEST_DATE_FORMAT="%Y-%m-%d"
 

--- a/app/defaults.env
+++ b/app/defaults.env
@@ -11,6 +11,12 @@ REPORT_FILE=true
 # Run the backup immediately on start
 BACKUP_ON_START=false
 
+# Create a new folder on each backup
+USE_DEST_DATE_FOLDER=false
+
+# Python Date format
+DEST_DATE_FORMAT="%Y-%m-%d"
+
 # Use the default rsync args "-ahq" (archive, human-readable, quiet)
 USE_DEFAULT_RSYNC_ARGS=true
 

--- a/app/defaults.env
+++ b/app/defaults.env
@@ -17,10 +17,6 @@ USE_DEST_DATE_FOLDER=false
 # Options are "container/date" or "date/container"
 DEST_DATE_PATH_FORMAT="date/container"
 
-# A and/or suffix prefix to the date folder."
-DEST_DATE_PATH_PREFIX=""
-DEST_DATE_PATH_SUFFIX=""
-
 # Python Date format
 DEST_DATE_FORMAT="%Y-%m-%d"
 

--- a/app/defaults.env
+++ b/app/defaults.env
@@ -17,6 +17,10 @@ USE_DEST_DATE_FOLDER=false
 # Options are "container/date" or "date/container"
 DEST_DATE_PATH_FORMAT="date/container"
 
+# A and/or suffix prefix to the date folder."
+DEST_DATE_PATH_PREFIX=""
+DEST_DATE_PATH_SUFFIX=""
+
 # Python Date format
 DEST_DATE_FORMAT="%Y-%m-%d"
 

--- a/app/nautical_env.py
+++ b/app/nautical_env.py
@@ -31,6 +31,7 @@ class NauticalEnv:
         self.NAUTICAL_DB_PATH = os.environ.get("NAUTICAL_DB_PATH", "")
 
         self.USE_DEST_DATE_FOLDER = os.environ.get("USE_DEST_DATE_FOLDER", "")
+        self.DEST_DATE_FORMAT = os.environ.get("DEST_DATE_FORMAT ", "")
 
         # Not associated with containers
         self.ADDITIONAL_FOLDERS = os.environ.get("ADDITIONAL_FOLDERS", "")

--- a/app/nautical_env.py
+++ b/app/nautical_env.py
@@ -32,6 +32,7 @@ class NauticalEnv:
 
         self.USE_DEST_DATE_FOLDER = os.environ.get("USE_DEST_DATE_FOLDER", "")
         self.DEST_DATE_FORMAT = os.environ.get("DEST_DATE_FORMAT ", "")
+        self.DEST_DATE_PATH_FORMAT = os.environ.get("DEST_DATE_PATH_FORMAT ", "")
 
         # Not associated with containers
         self.ADDITIONAL_FOLDERS = os.environ.get("ADDITIONAL_FOLDERS", "")

--- a/app/nautical_env.py
+++ b/app/nautical_env.py
@@ -30,6 +30,8 @@ class NauticalEnv:
 
         self.NAUTICAL_DB_PATH = os.environ.get("NAUTICAL_DB_PATH", "")
 
+        self.USE_DEST_DATE_FOLDER = os.environ.get("USE_DEST_DATE_FOLDER", "")
+
         # Not associated with containers
         self.ADDITIONAL_FOLDERS = os.environ.get("ADDITIONAL_FOLDERS", "")
         self.ADDITIONAL_FOLDERS_WHEN = os.environ.get("ADDITIONAL_FOLDERS_WHEN", "before")

--- a/app/nautical_env.py
+++ b/app/nautical_env.py
@@ -33,6 +33,8 @@ class NauticalEnv:
         self.USE_DEST_DATE_FOLDER = os.environ.get("USE_DEST_DATE_FOLDER", "")
         self.DEST_DATE_FORMAT = os.environ.get("DEST_DATE_FORMAT ", "")
         self.DEST_DATE_PATH_FORMAT = os.environ.get("DEST_DATE_PATH_FORMAT ", "")
+        self.DEST_DATE_PATH_PREFIX = os.environ.get("DEST_DATE_PATH_PREFIX ", "")
+        self.DEST_DATE_PATH_SUFFIX = os.environ.get("DEST_DATE_PATH_SUFFIX ", "")
 
         # Not associated with containers
         self.ADDITIONAL_FOLDERS = os.environ.get("ADDITIONAL_FOLDERS", "")

--- a/app/nautical_env.py
+++ b/app/nautical_env.py
@@ -31,10 +31,10 @@ class NauticalEnv:
         self.NAUTICAL_DB_PATH = os.environ.get("NAUTICAL_DB_PATH", "")
 
         self.USE_DEST_DATE_FOLDER = os.environ.get("USE_DEST_DATE_FOLDER", "")
-        self.DEST_DATE_FORMAT = os.environ.get("DEST_DATE_FORMAT ", "")
-        self.DEST_DATE_PATH_FORMAT = os.environ.get("DEST_DATE_PATH_FORMAT ", "")
-        self.DEST_DATE_PATH_PREFIX = os.environ.get("DEST_DATE_PATH_PREFIX ", "")
-        self.DEST_DATE_PATH_SUFFIX = os.environ.get("DEST_DATE_PATH_SUFFIX ", "")
+        self.DEST_DATE_FORMAT = os.environ.get("DEST_DATE_FORMAT", "%Y-%m-%d")
+        self.DEST_DATE_PATH_FORMAT = os.environ.get("DEST_DATE_PATH_FORMAT", "date/container")
+        if self.DEST_DATE_PATH_FORMAT not in ["date/container", "container/date"]:
+            self.DEST_DATE_PATH_FORMAT = "date/container"  # Set default
 
         # Not associated with containers
         self.ADDITIONAL_FOLDERS = os.environ.get("ADDITIONAL_FOLDERS", "")

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -25,11 +25,11 @@ services:
     labels:
       - "nautical-backup.enable=true"
       # - "nautical-backup.stop-before-backup=true"
-      - "nautical-backup.override-source-dir=watchtower-data"
+      # - "nautical-backup.override-source-dir=watchtower-data"
       # - "nautical-backup.additional-folders=add1"
       # - "nautical-backup.use-default-rsync-args=false"
-      - "nautical-backup.rsync-custom-args= "
-      - "nautical-backup.group=your-mom"
+      # - "nautical-backup.rsync-custom-args= "
+      # - "nautical-backup.group=your-mom"
 
   nautical-backup:
     # image: minituff/nautical-backup:2.0.0
@@ -46,6 +46,10 @@ services:
       - TZ=America/Los_Angeles
       - LOG_LEVEL=TRACE
       - BACKUP_ON_START=true
+      - REPORT_FILE=false
       - CRON_SCHEDULE=0 4 * * *
-      - REQUIRE_LABEL=true
+      # - REQUIRE_LABEL=true
       - HTTP_REST_API_ENABLED=true
+      - USE_DEST_DATE_FOLDER=true
+      # - DEST_DATE_PATH_FORMAT=container/date
+      # - DEST_DATE_FORMAT=Nautical Backup - %Y-%m-%d

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -28,6 +28,50 @@ Allow changing the schedule for when the backup is started.
 CRON_SCHEDULE=0 4 * * *
 ```
 
+## Create a Dated Destination Folder
+This option will tell Nautical to create a new destination folder on backup.
+
+For example: `/dest_folder/2024-04-05/contianer`
+
+> **Default**: false
+
+```properties
+USE_DEST_DATE_FOLDER=true
+```
+
+
+### Destination Folder Format
+
+Use the Python [time.strftime()](https://docs.python.org/3/library/time.html#time.strftime) module to format format the destination folder's name.
+
+> **Default**: %Y-%m-%d <small>(2024-04-05 for example)</small>
+
+> **Format**: Python [time.strftime()](https://docs.python.org/3/library/time.html#time.strftime) format
+
+```properties
+DEST_DATE_PATH_FORMAT=Nautical Backup - %Y-%m-%d
+```
+
+!!! tip "You are allowed to use almost anything in this field"
+    While it may be a intended to use the [date format](https://docs.python.org/3/library/time.html#time.strftime) here, you don't have to.
+    You could set this value to `latest backup` or insert addional text around the date format like this: `Nautical Backup - %Y-%m-%d`.
+    Use this setting to add a *prefix* and/or *suffix* to the dated folder.
+
+
+### Destination Folder Path
+Use this option to designate which path strategy is used when creating a dated destination directory.
+
+* `date/container` = */dest_folder/*`2024-04-05`*/container1*
+* `container/date` = */dest_folder/container1/*`2024-04-05`
+
+> **Default**: date/container
+
+> **Options**: `container/date` or `date/container`
+
+```properties
+DEST_DATE_PATH_FORMAT="date/container"
+```
+
 ## Additional Folders
 Allows Nautical to backup folders that are not associated with containers.
 

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -49,7 +49,7 @@ Use the Python [time.strftime()](https://docs.python.org/3/library/time.html#tim
 > **Format**: Python [time.strftime()](https://docs.python.org/3/library/time.html#time.strftime) format
 
 ```properties
-DEST_DATE_PATH_FORMAT=Nautical Backup - %Y-%m-%d
+DEST_DATE_FORMAT=Nautical Backup - %Y-%m-%d
 ```
 
 !!! tip "You are allowed to use almost anything in this field"

--- a/pytest/test_backup.py
+++ b/pytest/test_backup.py
@@ -1,4 +1,5 @@
 import os
+import time
 import pytest
 from pathlib import Path
 from mock import PropertyMock, mock, MagicMock, patch
@@ -981,6 +982,125 @@ class TestBackup:
             executable="/usr/bin/rsync",
             capture_output=False,
         )
+
+    @pytest.mark.parametrize(
+        "mock_container1",
+        [{"name": "container1", "id": "123456789"}],
+        indirect=True,
+    )
+    def test_get_dest_dir(
+        self,
+        mock_docker_client: MagicMock,
+        mock_container1: MagicMock,
+    ):
+        """Test test_get_dest_dir"""
+
+        mock_docker_client.containers.list.return_value = [mock_container1]
+        nb = NauticalBackup(mock_docker_client)
+        dest_name = nb._get_dest_dir(mock_container1, "container1")
+
+        assert str(dest_name) == f"{self.dest_location}/container1"
+
+    @pytest.mark.parametrize(
+        "mock_container1",
+        [{"name": "container1", "id": "123456789"}],
+        indirect=True,
+    )
+    def test_USE_DEST_DATE_FOLDER(
+        self,
+        mock_docker_client: MagicMock,
+        mock_container1: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test test_USE_DEST_DATE_FOLDER"""
+
+        time_format = time.strftime("%Y-%m-%d")
+
+        monkeypatch.setenv("USE_DEST_DATE_FOLDER", "true")
+
+        mock_docker_client.containers.list.return_value = [mock_container1]
+        nb = NauticalBackup(mock_docker_client)
+        dest_name = nb._get_dest_dir(mock_container1, "container1")
+
+        assert str(dest_name) == f"{self.dest_location}/{time_format}/container1"
+
+        monkeypatch.setenv("USE_DEST_DATE_FOLDER", "false")
+        nb = NauticalBackup(mock_docker_client)
+        dest_name = nb._get_dest_dir(mock_container1, "container1")
+        assert str(dest_name) == f"{self.dest_location}/container1"
+
+    @pytest.mark.parametrize(
+        "mock_container1",
+        [{"name": "container1", "id": "123456789"}],
+        indirect=True,
+    )
+    def test_DEST_DATE_PATH_FORMAT(
+        self,
+        mock_docker_client: MagicMock,
+        mock_container1: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test DEST_DATE_PATH_FORMAT"""
+
+        time_format = time.strftime("%Y-%m-%d")
+        monkeypatch.setenv("USE_DEST_DATE_FOLDER", "true")
+        mock_docker_client.containers.list.return_value = [mock_container1]
+
+        monkeypatch.setenv("DEST_DATE_PATH_FORMAT", "date/container")
+        nb = NauticalBackup(mock_docker_client)
+        dest_name = nb._get_dest_dir(mock_container1, "container1")
+
+        assert str(dest_name) == f"{self.dest_location}/{time_format}/container1"
+
+        monkeypatch.setenv("DEST_DATE_PATH_FORMAT", "container/date")
+        nb = NauticalBackup(mock_docker_client)
+        dest_name = nb._get_dest_dir(mock_container1, "container1")
+
+        assert str(dest_name) == f"{self.dest_location}/container1/{time_format}"
+
+        monkeypatch.setenv("DEST_DATE_PATH_FORMAT", "")
+        nb = NauticalBackup(mock_docker_client)
+        dest_name = nb._get_dest_dir(mock_container1, "container1")
+
+        assert str(dest_name) == f"{self.dest_location}/{time_format}/container1"
+
+    @pytest.mark.parametrize(
+        "mock_container1",
+        [{"name": "container1", "id": "123456789"}],
+        indirect=True,
+    )
+    def test_DEST_DATE_FORMAT(
+        self,
+        mock_docker_client: MagicMock,
+        mock_container1: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Test DEST_DATE_FORMAT"""
+
+        time_format = time.strftime("%Y-%m-%d")
+        monkeypatch.setenv("USE_DEST_DATE_FOLDER", "true")
+        mock_docker_client.containers.list.return_value = [mock_container1]
+
+        nb = NauticalBackup(mock_docker_client)
+        dest_name = nb._get_dest_dir(mock_container1, "container1")
+
+        assert str(dest_name) == f"{self.dest_location}/{time_format}/container1"
+
+        time_format_str = "%b %d %Y %H:%M:%S"
+        time_format = time.strftime(time_format_str)
+        monkeypatch.setenv("DEST_DATE_FORMAT", time_format_str)
+
+        nb = NauticalBackup(mock_docker_client)
+        dest_name = nb._get_dest_dir(mock_container1, "container1")
+        assert str(dest_name) == f"{self.dest_location}/{time_format}/container1"
+
+        time_format_str = "Prefix %D %T Suffix"
+        time_format = time.strftime(time_format_str)
+        monkeypatch.setenv("DEST_DATE_FORMAT", time_format_str)
+
+        nb = NauticalBackup(mock_docker_client)
+        dest_name = nb._get_dest_dir(mock_container1, "container1")
+        assert str(dest_name) == f"{self.dest_location}/{time_format}/container1"
 
     @mock.patch("subprocess.run")
     @pytest.mark.parametrize("mock_container1", [{"name": "container1", "id": "123456789"}], indirect=True)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 # Tests
 pytest==8.1.1
 pytest-cov==5.0.0
-black==24.4.0
+black==24.4.1
 httpx==0.27.0
 pytest-testdox==3.1.0
 mock==5.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,4 +11,4 @@ mock==5.1.0
 pre-commit==3.7.0
 
 # Docs
-mkdocs-material==9.5.18
+mkdocs-material==9.5.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.110.2
 pydantic==2.7.0
 uvicorn==0.29.0
-croniter==2.0.3
+croniter==2.0.5
 pytz==2024.1
 docker==7.0.0
 pydantic-settings==2.2.1


### PR DESCRIPTION
Originally created by @valdearg here https://github.com/Minituff/nautical-backup/pull/215. Thank you for the contribution!!

The goal if this PR is to have Nautical create a new folder (in a date format) each time it runs a backup.

To enable this feature set the `USE_DEST_DATE_FOLDER=false` environment variable.

For example: `/dest_folder/container_name/date (2024-04-05)`


## Requirements to Merge
- [x] USE_DEST_DATE_FOLDER implementation
- [x] DEST_DATE_FORMAT implementation
- [x] DEST_DATE_PATH_FORMAT implementation
- [x] Tests
- [x] Documentation updates