### PR TITLE
Allow disable of CRON schedule

### DIFF
--- a/app/api/nautical_router.py
+++ b/app/api/nautical_router.py
@@ -33,7 +33,7 @@ def dashboard(username: Annotated[str, Depends(authorize)]) -> JSONResponse:
 
     d = {
         "next_cron": next_crons,
-        "next_run": next_crons.get("1", [None, None])[1],
+        "next_run": next_crons.get("1", [None, None])[1] if next_crons else None,
         "last_cron": db.get("last_cron", "None"),
         "number_of_containers": db.get("number_of_containers", 0),
         "completed": db.get("containers_completed", 0),

--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -5,7 +5,13 @@ import os
 from datetime import datetime
 
 
-def next_cron_occurrences(occurrences: Optional[int] = 5, now: Optional[datetime] = None) -> dict[str | int, Any]:
+def next_cron_occurrences(
+    occurrences: Optional[int] = 5, now: Optional[datetime] = None
+) -> Optional[dict[str | int, Any]]:
+    cron_enabled = os.getenv("CRON_SCHEDULE_ENABLED", "true").lower()
+    if cron_enabled == "false":
+        return None
+
     cron_expression = os.getenv("CRON_SCHEDULE", "0 4 * * *")
     timezone = os.getenv("TZ", "Etc/UTC")
     tz = pytz.timezone(timezone)

--- a/app/defaults.env
+++ b/app/defaults.env
@@ -5,6 +5,9 @@ TZ=Etc/UTC
 # Default = Every day at 4am
 CRON_SCHEDULE=0 4 * * *
 
+# Enable Nautical to run on a CRON schedule
+CRON_SCHEDULE_ENABLED=true
+
 # Default enable the report file
 REPORT_FILE=true
 

--- a/app/entry.sh
+++ b/app/entry.sh
@@ -19,7 +19,12 @@ install_cron(){
     # Install the new cron jobs and remove the tempcron file
     crontab tempcron && rm tempcron
 }
-install_cron
+
+if [ "$CRON_SCHEDULE_ENABLED" = "true" ]; then
+    install_cron
+else
+    logThis "Skipping CRON installation since CRON_SCHEDULE_ENABLED=false" "INFO" "init"
+fi
 
 # Verify the source and destination locations
 verify_source_location $SOURCE_LOCATION

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -28,6 +28,17 @@ Allow changing the schedule for when the backup is started.
 CRON_SCHEDULE=0 4 * * *
 ```
 
+## Enable/Disable CRON Schedule
+Completely disable the recurring backup via a CRON scheudle.
+
+This could be useful if you want to run Nautical manually via [Backup On Start](#backup-on-start) or the [Rest API](./rest-api.md).
+
+> **Default**: true <small>(CRON enabled)</small>
+
+```properties
+CRON_SCHEDULE_ENABLED=false
+```
+
 ## Additional Folders
 Allows Nautical to backup folders that are not associated with containers.
 

--- a/pytest/test_api.py
+++ b/pytest/test_api.py
@@ -96,9 +96,9 @@ class TestAPI:
         assert response.json()["completed"] == db.get("containers_completed", 0)
         assert response.json()["number_of_containers"] == db.get("number_of_containers", 0)
         assert response.json()["last_cron"] == db.get("last_cron", "None")
-        assert response.json()["next_run"] == next_crons.get("1", [None, None])[1]
+        assert response.json()["next_run"] == next_crons.get("1", [None, None])[1] if next_crons else None
         assert len(response.json()["next_cron"]) == 7
-        assert set(response.json()["next_cron"]) == set(next_crons)
+        assert set(response.json()["next_cron"]) == set(next_crons) if next_crons else None
 
     @patch("subprocess.run")
     def test_start_backup(self, patched_subprocess_run):

--- a/pytest/test_utils.py
+++ b/pytest/test_utils.py
@@ -57,3 +57,12 @@ class TestUtils:
         monkeypatch.setenv("CRON_SCHEDULE_ENABLED", "false")
         faked_now = datetime.datetime(2022, 1, 1, 14, 0, 0)
         assert next_cron_occurrences(1, faked_now) == None
+
+    def test_next_cron_occurrences_with_bad_value(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("CRON_SCHEDULE_ENABLED", "oogabooga")
+        faked_now = datetime.datetime(2022, 1, 1, 14, 0, 0)
+        res = next_cron_occurrences(1, faked_now)
+        assert res and res["cron"] == "0 4 * * *"

--- a/pytest/test_utils.py
+++ b/pytest/test_utils.py
@@ -49,3 +49,11 @@ class TestUtils:
             "tz": "America/Phoenix",
             "1": ["Thursday, November 02, 2023 at 08:00 AM", "11/02/23 08:00"],
         }
+
+    def test_next_cron_occurrences_disabled(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("CRON_SCHEDULE_ENABLED", "false")
+        faked_now = datetime.datetime(2022, 1, 1, 14, 0, 0)
+        assert next_cron_occurrences(1, faked_now) == None

--- a/tests/_integration_tests.sh
+++ b/tests/_integration_tests.sh
@@ -278,6 +278,7 @@ declare -A expected_env_vars=(
     ["TZ"]="Etc/UTC"
     ["TEST_MODE"]="2" # This not actually the default, but the mode that checks this value is #2
     ["CRON_SCHEDULE"]="0 4 * * *"
+    ["CRON_SCHEDULE_ENABLED"]="true"
     ["REPORT_FILE"]="true"
     ["BACKUP_ON_START"]="false"
     ["USE_DEFAULT_RSYNC_ARGS"]="true"


### PR DESCRIPTION
## Enable/Disable CRON Schedule
Completely disable the recurring backup via a CRON scheudle.

This could be useful if you want to run Nautical manually via [Backup On Start](#backup-on-start) or the [Rest API](./rest-api.md).

> **Default**: true <small>(CRON enabled)</small>

```properties
CRON_SCHEDULE_ENABLED=false
```