### PR TITLE
Change curls to execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ services:
     container_name: nautical-backup
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - /config:/config
       - /source:/app/source
       - /destination:/app/destination
     environment: # Optional variables
@@ -43,6 +44,7 @@ Docker CLI
 docker run -d \
   --name nautical-backup \
   -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /config:/config \
   -v /source:/app/source \
   -v /destination:/app/destination \
   -e TZ="America/Los_Angeles" \

--- a/app/backup.py
+++ b/app/backup.py
@@ -87,6 +87,7 @@ class NauticalBackup:
         try:
             name = c.name
             c_id = c.id
+            c_image = c.image
         except ImageNotFound as e:
             self.log_this(f"Skipping container because it's image was not found.", "TRACE")
             return True

--- a/app/backup.py
+++ b/app/backup.py
@@ -238,7 +238,12 @@ class NauticalBackup:
             return None
 
         self.log_this(f"Running CURL command: {command}")
-        out = subprocess.run(command, shell=True, executable="/bin/bash", capture_output=False)
+        out = subprocess.run(command, shell=True, executable="/bin/bash", capture_output=True)
+
+        if out.stderr:
+            self.log_this(f"Exec command error: {out.stderr}", "WARN")
+        self.log_this(f"Exec command output: {out.stdout}", "DEBUG")
+
         return out
 
     def _run_lifecyle_hook(self, c: Container, when: BeforeOrAfter):

--- a/app/backup.py
+++ b/app/backup.py
@@ -181,11 +181,28 @@ class NauticalBackup:
 
         return containers_by_group
 
+    def _set_exec_enviornment_variables(self, vars: Dict[str, str]):
+        """Set the environment variables for the exec command"""
+        for k, v in vars.items():  # Loop through all the variables in the class
+            self.log_this(f"Setting environment variable {k} to {v}", "TRACE")
+            os.environ[k] = v  # Set the environment variable
+
     def _run_curl(
-        self, c: Optional[Container], when: BeforeAfterorDuring, attached_to_container=False
+        self,
+        c: Optional[Container],
+        when: BeforeAfterorDuring,
+        attached_to_container=False,
     ) -> Optional[subprocess.CompletedProcess[bytes]]:
         """Runs a curl command from the Nautical Container itself."""
         command = ""  # Curl command
+
+        vars: Dict[str, str] = {
+            "NB_EXEC_ATTACHED_TO_CONTAINER": str(attached_to_container),
+            "NB_EXEC_CONTAINER_NAME": str(c.name) if c else "None",
+            "NB_EXEC_CONTAINER_ID": str(c.id) if c else "None",
+            "NB_EXEC_BEFORE_DURING_OR_AFTER": str(when),
+        }
+        self._set_exec_enviornment_variables(vars)
 
         if attached_to_container == True and c:
             if when == BeforeAfterorDuring.BEFORE:

--- a/app/backup.py
+++ b/app/backup.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 import time
+import codecs
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
@@ -241,8 +242,8 @@ class NauticalBackup:
         out = subprocess.run(command, shell=True, executable="/bin/bash", capture_output=True)
 
         if out.stderr:
-            self.log_this(f"Exec command error: {out.stderr}", "WARN")
-        self.log_this(f"Exec command output: {out.stdout}", "DEBUG")
+            self.log_this(f"Exec command error: {codecs.decode(out.stderr, 'utf-8').strip()}", "WARN")
+        self.log_this(f"Exec command output: {codecs.decode(out.stdout, 'utf-8').strip()}", "DEBUG")
 
         return out
 

--- a/app/backup.py
+++ b/app/backup.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
 import docker
-from docker.errors import APIError
+from docker.errors import APIError, ImageNotFound
 from docker.models.containers import Container
 
 from app.api.config import Settings
@@ -83,6 +83,14 @@ class NauticalBackup:
 
         # Skip self
         SELF_CONTAINER_ID = self.env.SELF_CONTAINER_ID
+
+        try:
+            name = c.name
+            c_id = c.id
+        except ImageNotFound as e:
+            self.log_this(f"Skipping container because it's image was not found.", "TRACE")
+            return True
+
         if "minituff/nautical-backup" in str(c.image):
             self.log_this(f"Skipping {c.name} {c.id} because it's image matches 'minituff/nautical-backup'.", "TRACE")
         if c.labels.get("org.opencontainers.image.title") == "nautical-backup":

--- a/app/backup.py
+++ b/app/backup.py
@@ -197,14 +197,6 @@ class NauticalBackup:
         """Runs a curl command from the Nautical Container itself."""
         command = ""  # Curl command
 
-        vars: Dict[str, str] = {
-            "NB_EXEC_ATTACHED_TO_CONTAINER": str(attached_to_container),
-            "NB_EXEC_CONTAINER_NAME": str(c.name) if c else "None",
-            "NB_EXEC_CONTAINER_ID": str(c.id) if c else "None",
-            "NB_EXEC_BEFORE_DURING_OR_AFTER": str(when),
-        }
-        self._set_exec_enviornment_variables(vars)
-
         if attached_to_container == True and c:
             if when == BeforeAfterorDuring.BEFORE:
                 command = str(c.labels.get("nautical-backup.curl.before", ""))
@@ -237,6 +229,15 @@ class NauticalBackup:
         # Example command "curl -o /app/destination/google google.com"
         if not str(command) or str(command) == "" or str(command) == "None":
             return None
+
+        vars: Dict[str, str] = {
+            "NB_EXEC_COMMAND": str(command),
+            "NB_EXEC_ATTACHED_TO_CONTAINER": str(attached_to_container),
+            "NB_EXEC_CONTAINER_NAME": str(c.name) if c else "None",
+            "NB_EXEC_CONTAINER_ID": str(c.id) if c else "None",
+            "NB_EXEC_BEFORE_DURING_OR_AFTER": str(when.name),
+        }
+        self._set_exec_enviornment_variables(vars)
 
         self.log_this(f"Running CURL command: {command}")
         out = subprocess.run(command, shell=True, executable="/bin/bash", capture_output=True)

--- a/app/backup.py
+++ b/app/backup.py
@@ -81,15 +81,13 @@ class NauticalBackup:
     def _should_skip_container(self, c: Container) -> bool:
         """Use logic to determine if a container should be skipped by nautical completely"""
 
-        # Skip self
-        SELF_CONTAINER_ID = self.env.SELF_CONTAINER_ID
+        SELF_CONTAINER_ID = self.env.SELF_CONTAINER_ID  # Used to skip self
 
         try:
-            name = c.name
-            c_id = c.id
-            c_image = c.image
+            # Attempt to pull info from container. Skip if not found
+            info = str(c.name) + " " + str(c.id) + " " + str(c.image) + " " + str(c.labels)
         except ImageNotFound as e:
-            self.log_this(f"Skipping container because it's image was not found.", "TRACE")
+            self.log_this(f"Skipping container because it's info was not found.", "TRACE")
             return True
 
         if "minituff/nautical-backup" in str(c.image):

--- a/app/nautical_env.py
+++ b/app/nautical_env.py
@@ -40,8 +40,15 @@ class NauticalEnv:
         self.ADDITIONAL_FOLDERS = os.environ.get("ADDITIONAL_FOLDERS", "")
         self.ADDITIONAL_FOLDERS_WHEN = os.environ.get("ADDITIONAL_FOLDERS_WHEN", "before")
 
-        self.PRE_BACKUP_CURL = os.environ.get("PRE_BACKUP_CURL", "")
-        self.POST_BACKUP_CURL = os.environ.get("POST_BACKUP_CURL", "")
+        self._PRE_BACKUP_CURL = os.environ.get("PRE_BACKUP_CURL", "")
+        self._POST_BACKUP_CURL = os.environ.get("POST_BACKUP_CURL", "")
+
+        self.PRE_BACKUP_EXEC = os.environ.get(
+            "PRE_BACKUP_EXEC", self._PRE_BACKUP_CURL
+        )  # Temporily use the CURL variable
+        self.POST_BACKUP_EXEC = os.environ.get(
+            "POST_BACKUP_EXEC", self._POST_BACKUP_CURL
+        )  # Temporily use the CURL variable
 
         self.RUN_ONCE = False
         if os.environ.get("RUN_ONCE", "False").lower() == "true":

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -23,20 +23,15 @@ services:
       - WATCHTOWER_SCHEDULE=0 0 4 * * * # Every day at 4am
     labels:
       - "nautical-backup.enable=true"
-      # - "nautical-backup.stop-before-backup=true"
-      # - "nautical-backup.override-source-dir=watchtower-data"
-      # - "nautical-backup.additional-folders=add1"
-      # - "nautical-backup.use-default-rsync-args=false"
-      # - "nautical-backup.rsync-custom-args= "
-      # - "nautical-backup.group=your-mom"
+      # - "nautical-backup.curl.before=echo NB_EXEC_ATTACHED_TO_CONTAINER: $$NB_EXEC_ATTACHED_TO_CONTAINER"
+      # - "nautical-backup.curl.before=/config/script.sh"
 
   nautical-backup:
-    # image: minituff/nautical-backup:2.0.0
     image: nautical-backup:test
     container_name: nautical-backup-test
     volumes:
-      # - ${LOCAL_WORKSPACE_FOLDER-./}/dev/source:/app/source
-      # - ${LOCAL_WORKSPACE_FOLDER-./}/dev/destination:/app/destination
+      - ${LOCAL_WORKSPACE_FOLDER-./}/dev/source:/app/source
+      - ${LOCAL_WORKSPACE_FOLDER-./}/dev/destination:/app/destination
       - ${LOCAL_WORKSPACE_FOLDER-./}/dev/config:/config
       - ${LOCAL_WORKSPACE_FOLDER-./}/app:/app
       - /var/run/docker.sock:/var/run/docker.sock

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     labels:
       - "nautical-backup.enable=true"
       # - "nautical-backup.curl.before=echo NB_EXEC_ATTACHED_TO_CONTAINER: $$NB_EXEC_ATTACHED_TO_CONTAINER"
-      # - "nautical-backup.curl.before=/config/script.sh"
+      - "nautical-backup.curl.before=/config/script.sh"
 
   nautical-backup:
     image: nautical-backup:test

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -240,23 +240,23 @@ Normally, a container is backed to a folder with the ^^same name^^ as the `conta
 <small>🔄 This is the same action as the [Override Destination Directory](./labels.md#override-destination-directory-name) label, but applied globally.</small>
 
 
-## Curl Requests
-Send a `CURL` request *before* or *after* backing up ^^all^^ the containers. This can be used to alert services before shutdown and/or ensure the services came online correctly.
+## Execute Commands before or after backup
+Execute a command *before* or *after* backing up ^^all^^ the containers. This can be used to alert services before shutdown and/or ensure the services came online correctly.
 
-This CURL will run before/after the entire backup process is initiated.
+This command will run before/after the entire backup process is initiated.
 
 > **Default**: *empty* <small>(nothing will be done)</small>
 
-> **FORMAT**: The entirety of a `curl` request
+> **FORMAT**: The entirety of a `command`
 
 ```properties
-PRE_BACKUP_CURL=curl -X GET 'google.com'
-POST_BACKUP_CURL=curl -d "Backup successful 😀" ntfy.sh/mytopic
+PRE_BACKUP_EXEC=/config/prepare-for-backup.sh
+POST_BACKUP_EXEC=curl -d "Backup successful 😀" ntfy.sh/mytopic
 ```
 
 ------8<------ "exec_request_example.md"
 
-<small>🔄 This is the same action as the [Curl Requests](./labels.md#curl-requests) label, but applied globally (not per container).</small>
+<small>🔄 This is the same action as the [Execute Commands](./labels.md#execute-commands) label, but applied globally (not per container).</small>
 
 ## Report file
 Enable or Disable the automatically generated report file.

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -117,8 +117,8 @@ ADDITIONAL_FOLDERS_WHEN=after
     The `additional2` folder already exists within the `/opt/volume-data` so it does not need a mount point.
 
     ```yaml
-    ------8<------ "docker-compose-example-no-tooltips.yml:3:8"
-          - /opt/volume-data:/app/source
+    ------8<------ "docker-compose-example-no-tooltips.yml:3:9"
+          - /opt/volume-data:/app/source #(4)!
           - /mnt/nfs-share/backups:/app/destination
           - /mnt/additional:/app/source/additional #(1)!
         environment:
@@ -129,7 +129,8 @@ ADDITIONAL_FOLDERS_WHEN=after
     1. Mount `additional` inside the `/app/source` directory in the container
     2. Tell Nautical to process both the `additional` and `additional2` folders
     3. Tell Nautical *when* to backup the additional folders.
-            * `before` is the default 
+            * `before` is the default
+    4. The `additional2` folder already exists within the `/opt/volume-data` so it does not need a mount point.
 
 !!! abstract "If the same folder is named in the [Additional Folders](./labels.md#additional-folders) label and a service env variable--it will be backed up twice."
 
@@ -253,15 +254,7 @@ PRE_BACKUP_CURL=curl -X GET 'google.com'
 POST_BACKUP_CURL=curl -d "Backup successful 😀" ntfy.sh/mytopic
 ```
 
-!!! example "Test your `curl` request"
-    Before setting the environment variable, it is a good idea to ensure it works first. Here is an example.
-
-    Ensure Nautical is running first, then run:
-    ```bash
-    docker exec -it nautical-backup \
-      curl -X GET 'google.com'
-    ```
-    **Note:** You can only have 1 *before* and 1 *after* Curl Request. This applies to Nautical itself, not to each container.
+------8<------ "exec_request_example.md"
 
 <small>🔄 This is the same action as the [Curl Requests](./labels.md#curl-requests) label, but applied globally (not per container).</small>
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -26,7 +26,7 @@ Let's take a look at an example:
 !!! example "Here is how Nautical fits into the *Sample Configuration*"
     === "Docker Compose"
         ```yaml
-        ------8<------ "docker-compose-example.yml:3:8"
+        ------8<------ "docker-compose-example.yml:3:9"
               - /opt/docker-volumes:/app/source #(2)!
               - /mnt/nfs-share/backups:/app/destination #(3)!
         ```

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -302,7 +302,7 @@ nautical-backup.additional-folders.when=after
           labels:
             - "nautical-backup.additional-folders=service-additional"
         
-        ------8<------ "docker-compose-example-no-tooltips.yml:4:10"
+        ------8<------ "docker-compose-example-no-tooltips.yml:4:11"
         ```
         
 === "Example 2"
@@ -320,7 +320,7 @@ nautical-backup.additional-folders.when=after
             - "nautical-backup.additional-folders=service-additional"
             - "nautical-backup.additional-folders.when=after"
         
-        ------8<------ "docker-compose-example-no-tooltips.yml:4:10"
+        ------8<------ "docker-compose-example-no-tooltips.yml:4:11"
               - /mnt/service-additional:/app/source/service-additional #(1)!
         ```
 

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -381,36 +381,32 @@ nautical-backup.keep_src_dir_name=false
 <small>🔄 This is the same action as the [Mirror Source Directory Name to Destination](./arguments.md#mirror-source-directory-name-to-destination) variable, but applied only to this container.</small>
 
 
-## Curl Requests
-Send a `CURL` request *before* or *after* backing up the container. This can be used to alert the service before shutdown and/or ensure the service came online correctly.
+## Execute Commands
+Execute a command *before*, *after* or *during* backing up the container. This can be used to alert the service before shutdown and/or ensure the service came online correctly.
 
 > **Default**: *empty* <small>(nothing will be done)</small>
 
-> **FORMAT**: The entirety of a `curl` request
+> **FORMAT**: The entirety of a `command`
 
 
 ```properties
-nautical-backup.curl.before=curl -X GET 'google.com'
-nautical-backup.curl.after=curl -X POST 'http://192.168.1.21.com/do-something'
-nautical-backup.curl.during=curl -X PATCH 'bing.com'
+nautical-backup.exec.before=/config/prepare-for-backup.sh
+nautical-backup.exec.after=curl -X POST 'http://192.168.1.21.com/do-something'
+nautical-backup.exec.during=curl -X PATCH 'bing.com'
 ```
 
-There are 3 moments when you can run a `curl` request <small>(You can use more than 1)</small>:
+!!! tip "Remeber, these commands are exectuted by the Nautical-Backup container, not the child container."
+    If you need to exectute commands inside the continer being backed up, see [lifecycle hooks](#lifecycle-hooks).
 
-- [ ] **Before** - Run the `curl` command *before* the parent container is stopped.
-- [ ] **After** -  Run the `curl` command *after* the parent container is restarted.
-- [ ] **During** - Run the `curl` command while the parent container is stopped <small>(Before it is restarted)</small>.
+There are 3 moments when you can run a *command* <small>(You can use more than 1)</small>:
 
-!!! example "Test your `curl` request"
-    Before setting the environment variable, it is a good idea to ensure it works first. Here is an example.
+- [ ] **Before** - Run the command *before* the parent container is stopped.
+- [ ] **After** -  Run the command *after* the parent container is restarted.
+- [ ] **During** - Run the command while the parent container is stopped <small>(Before it is restarted)</small>.
 
-    Ensure Nautical is running first, then run:
-    ```bash
-    docker exec -it nautical-backup \
-      curl -X GET 'google.com'
-    ```
+------8<------ "exec_request_example.md"
 
-<small>🔄 This is the same action as the [Curl Requests](./arguments.md#curl-requests) variable, but applied only to this container.</small>
+<small>🔄 This is the same action as the [Execute Commands](./arguments.md#execute-commands-before-or-after-backup) variable, but applied only to this container.</small>
 
 ## Lifecycle Hooks
 Lifecycle Hooks allow you to run a command ==*inside* the container that Nautical is backing up==.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -9,7 +9,7 @@ The API is ^^enabled internally by default^^, but you still must open the port f
 You need to ensure the port is opened by Docker for the Nautical container. See the ==highlighted== sections of this example Nautical config:
 
 === "Docker Compose"
-    ```yaml hl_lines="11 12 13"
+    ```yaml hl_lines="11 12"
     ------8<------ "docker-compose-example-no-tooltips.yml:0:11"
         ports:
           - "8069:8069/tcp"
@@ -17,10 +17,10 @@ You need to ensure the port is opened by Docker for the Nautical container. See 
     
 === "Docker Cli"
 
-    ```bash hl_lines="6 6"
-    ------8<------ "docker-run-example-no-tooltips.sh::6"
+    ```bash hl_lines="7 7"
+    ------8<------ "docker-run-example-no-tooltips.sh::7"
       -p 8069:8069/tcp \
-    ------8<------ "docker-run-example-no-tooltips.sh:10:"
+    ------8<------ "docker-run-example-no-tooltips.sh:11:"
     ```
 
 ### 2. Verify it works

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -30,15 +30,13 @@ This will need to be done each time a new version is released.
 === "Docker Compose"
     ```yaml hl_lines="3"
     ------8<------ "docker-compose-semver-example.yml:3"
-    ------8<------ "docker-compose-example.yml:6:10"
+        # Rest of config...
     ```
-    
-    ------8<------ "docker-example-tooltips.md"
 
 === "Docker Cli"
 
     ```bash hl_lines="6"
-    ------8<------ "docker-run-example.sh::6"
+    ------8<------ "docker-run-example.sh::7"
     ------8<------ "docker-run-semver-example.sh"
 
       # Update the version number in the line above
@@ -58,7 +56,8 @@ While convenient, automatic updates may break things. For this reason we recomme
 
         === "Docker Compose"
             ```yaml hl_lines="3"
-            ------8<------ "docker-compose-example.yml:3:10"
+            ------8<------ "docker-compose-example.yml:3:5"
+                # Rest of config...
               
               watchtower:
                 image: containrrr/watchtower:latest
@@ -74,9 +73,9 @@ While convenient, automatic updates may break things. For this reason we recomme
                 Remove this line to update all containers.
 
         === "Docker Cli"
-            ```bash hl_lines="6"
-            ------8<------ "docker-run-example.sh::6"
-            ------8<------ "docker-run-example.sh:10:"
+            ```bash hl_lines="7"
+            ------8<------ "docker-run-example.sh::7"
+            ------8<------ "docker-run-example.sh:11:"
             
             docker run -d \
               --name watchtower \
@@ -96,8 +95,9 @@ While convenient, automatic updates may break things. For this reason we recomme
 
         === "Docker Compose"
             ```yaml hl_lines="3"
-            ------8<------ "docker-compose-semver-major-example.yml:3:10"
-              
+            ------8<------ "docker-compose-semver-major-example.yml:3:5"
+                # Rest of config...
+
               watchtower:
                 image: containrrr/watchtower:latest
                 container_name: watchtower
@@ -112,8 +112,8 @@ While convenient, automatic updates may break things. For this reason we recomme
                 Remove this line to update all containers.
 
         === "Docker Cli"
-            ```bash  hl_lines="6"
-            ------8<------ "docker-run-example.sh::6"
+            ```bash  hl_lines="7"
+            ------8<------ "docker-run-example.sh::7"
             ------8<------ "docker-run-semver-major-example.sh"
             
             docker run -d \
@@ -142,8 +142,8 @@ While convenient, automatic updates may break things. For this reason we recomme
             ```yaml hl_lines="3"
             ------8<------ "docker-compose-example.yml:3:4"
                 image: minituff/nautical-backup:latest
-            ------8<------ "docker-compose-example.yml:6:10"
-              
+                # Rest of config...
+
               watchtower:
                 image: containrrr/watchtower:latest
                 container_name: watchtower
@@ -158,8 +158,8 @@ While convenient, automatic updates may break things. For this reason we recomme
                 Remove this line to update all containers.
 
         === "Docker Cli"
-            ```bash  hl_lines="6"
-            ------8<------ "docker-run-example.sh::6"
+            ```bash  hl_lines="7"
+            ------8<------ "docker-run-example.sh::7"
               minituff/nautical-backup:latest
             
             docker run -d \

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,7 +49,11 @@ nav:
    - Contributing to the Docs: developers/docs.md
    - Developer Env Variables: developers/env.md
 
-
+watch:
+  - snippets
+  - docs
+  - mkdocs.yml
+  
 extra:
   generator: false  # "false" will Remove the "Made with Material for MkDocs" branding
   # version:

--- a/pytest/test_backup.py
+++ b/pytest/test_backup.py
@@ -1687,6 +1687,42 @@ class TestBackup:
         assert mock_subprocess_run.call_args_list[2][0][0] == "curl -X GET 'msn.com'"
         assert mock_subprocess_run.call_args_list[3][0][0] == "curl -X GET 'espn.com'"
 
+    @pytest.mark.parametrize(
+        "mock_container1",
+        [
+            {
+                "name": "container1",
+                "id": "123456789",
+                "labels": {
+                    "nautical-backup.curl.before": "This will be set later, in the function",
+                },
+            }
+        ],
+        indirect=True,
+    )
+    def test_exec_variables_label(
+        self,
+        mock_docker_client: MagicMock,
+        mock_container1: MagicMock,
+    ):
+        """Test curl commands by labels"""
+        container_name = "cont1"
+        container_id = "9839343"
+
+        # Set mock attributes
+        mock_container1.__setattr__("name", container_name)
+        mock_container1.__setattr__("id", container_id)
+        mock_container1.__setattr__(
+            "labels",
+            {
+                "nautical-backup.curl.before": "echo container_id: $NB_EXEC_CONTAINER_NAME container_id: $NB_EXEC_CONTAINER_ID",
+            },
+        )
+
+        mock_docker_client.containers.list.return_value = [mock_container1]
+        nb = NauticalBackup(mock_docker_client)
+        nb.backup()
+
     @mock.patch("subprocess.run")
     @pytest.mark.parametrize(
         "mock_container1",

--- a/snippets/docker-compose-example-no-tooltips.yml
+++ b/snippets/docker-compose-example-no-tooltips.yml
@@ -6,6 +6,7 @@ services:
     container_name: nautical-backup
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - /config:/config
       - /source:/app/source
       - /destination:/app/destination
     environment:

--- a/snippets/docker-compose-example.yml
+++ b/snippets/docker-compose-example.yml
@@ -6,6 +6,7 @@ services:
     container_name: nautical-backup
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock #(1)!
+      - /config:/config #(9)!
       - /source:/app/source #(2)!
       - /destination:/app/destination #(3)!
     environment: # Optional variables (4)

--- a/snippets/docker-example-tooltips.md
+++ b/snippets/docker-example-tooltips.md
@@ -8,3 +8,4 @@
 7. It is recommended to avoid using the `latest` tag.
     * This project is under active development, using a exact tag can help avoid updates breaking things.
 8. Set the time-zone. See this [Wikipedia page](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for a list of available time-zones.
+9. Configuration folder. This directory will will Nautical's internal database which stores metrics and history.

--- a/snippets/docker-run-example-no-tooltips.sh
+++ b/snippets/docker-run-example-no-tooltips.sh
@@ -2,6 +2,7 @@
 docker run -d \
   --name nautical-backup \
   -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /config:/config \
   -v /source:/app/source \
   -v /destination:/app/destination \
   -e TZ="America/Los_Angeles" \

--- a/snippets/docker-run-example.sh
+++ b/snippets/docker-run-example.sh
@@ -2,6 +2,7 @@
 docker run -d \
   --name nautical-backup \
   -v /var/run/docker.sock:/var/run/docker.sock \ #(1)!
+  -v /cofig:/config \ #(9)!
   -v /source:/app/source \ #(2)!
   -v /destination:/app/destination \ #(3)!
   -e TZ="America/Los_Angeles" \ #(8)!

--- a/snippets/exec_request_example.md
+++ b/snippets/exec_request_example.md
@@ -1,4 +1,4 @@
-!!! example "Test your `exec`"
+??? example "Test your `exec`"
     Before setting the variable/label, it is a good idea to ensure it works first. Here is an example.
 
     Ensure Nautical is running first, then run:
@@ -9,23 +9,52 @@
     **Note:** You can only have 1 *before* and 1 *after* Curl Request. This applies to Nautical itself, not to each container.
 
 
-??? abstract "Running a script"
+??? abstract "Executing a script"
     If you need to run more than a simple one-liner, we can run an entire script instead.
     Here is a basic example:
 
     Create a file <small>(we will name it `script.sh`)</small> and place it in the mounted `/config` directory.
 
-    **Remeber:** We set the `/config` folder as part of the [Installation](./installation.md).
+      **Remember:** We mounted the `/config` folder as part of the [Installation](./installation.md).
     
     ```bash
     #!/usr/bin/env bash
 
     echo "Hello from script.sh"
 
-    echo "NB_EXEC_COMMAND: $NB_EXEC_COMMAND" 
-    echo "NB_EXEC_ATTACHED_TO_CONTAINER: $NB_EXEC_ATTACHED_TO_CONTAINER" 
+    # Variable usage example
     echo "NB_EXEC_CONTAINER_NAME: $NB_EXEC_CONTAINER_NAME" 
     echo "NB_EXEC_CONTAINER_ID: $NB_EXEC_CONTAINER_ID" 
-    echo "NB_EXEC_BEFORE_DURING_OR_AFTER: $NB_EXEC_BEFORE_DURING_OR_AFTER" 
-
     ```
+
+    Give the file execution permission: `chmod +x /config/script.sh`
+
+    **Test the script**
+
+    Ensure Nautical is running first, then run:
+    ```bash
+    docker exec -it nautical-backup \
+      /bin/bash /config/script.sh
+    ```
+
+??? quote "Available Enviornment Variables"
+
+    | Method                           | Description                                                                             |
+    |:---------------------------------|:----------------------------------------------------------------------------------------|
+    | `NB_EXEC_CONTAINER_NAME`         | The container name*                                                                     |
+    | `NB_EXEC_CONTAINER_ID`           | The contianer ID*                                                                       |
+    | `NB_EXEC_BEFORE_DURING_OR_AFTER` | When is this command being. [Options](./arguments.md#when-to-backup-additional-folders) |
+    | `NB_EXEC_COMMAND`                | The exact command exectuted                                                             |
+    | `NB_EXEC_ATTACHED_TO_CONTAINER`  | Is this exec command attached to a container                                            |
+
+    <small> *Require access to a container. Eg. When `NB_EXEC_ATTACHED_TO_CONTAINER=true`</small> 
+
+    💰 **Tip:** To use the enviornment variables in a docker-compose file, you will need to escape them with a double `$`:
+    ```yaml
+    labels:
+      - "nautical-backup.curl.before=echo name: $$NB_EXEC_CONTAINER_NAME" # (1)!
+    ```
+
+    1. Notice the double `$$`
+
+    🛎️ Want any additional enviornment variables? Submit an [issue](https://github.com/Minituff/nautical-backup/issues/new).

--- a/snippets/exec_request_example.md
+++ b/snippets/exec_request_example.md
@@ -1,0 +1,31 @@
+!!! example "Test your `exec`"
+    Before setting the variable/label, it is a good idea to ensure it works first. Here is an example.
+
+    Ensure Nautical is running first, then run:
+    ```bash
+    docker exec -it nautical-backup \
+      curl -X GET 'google.com'
+    ```
+    **Note:** You can only have 1 *before* and 1 *after* Curl Request. This applies to Nautical itself, not to each container.
+
+
+??? abstract "Running a script"
+    If you need to run more than a simple one-liner, we can run an entire script instead.
+    Here is a basic example:
+
+    Create a file <small>(we will name it `script.sh`)</small> and place it in the mounted `/config` directory.
+
+    **Remeber:** We set the `/config` folder as part of the [Installation](./installation.md).
+    
+    ```bash
+    #!/usr/bin/env bash
+
+    echo "Hello from script.sh"
+
+    echo "NB_EXEC_COMMAND: $NB_EXEC_COMMAND" 
+    echo "NB_EXEC_ATTACHED_TO_CONTAINER: $NB_EXEC_ATTACHED_TO_CONTAINER" 
+    echo "NB_EXEC_CONTAINER_NAME: $NB_EXEC_CONTAINER_NAME" 
+    echo "NB_EXEC_CONTAINER_ID: $NB_EXEC_CONTAINER_ID" 
+    echo "NB_EXEC_BEFORE_DURING_OR_AFTER: $NB_EXEC_BEFORE_DURING_OR_AFTER" 
+
+    ```


### PR DESCRIPTION
We are making the switch from `curl` requests to `execute command`.

The functionality is the same, but better! Now you will have access to some environment variables that you can use in your scripts.

### Environment Variable Changes
* `PRE_BACKUP_CURL` --> `PRE_BACKUP_EXEC`
* `POST_BACKUP_CURL` --> `POST_BACKUP_EXEC`
### Label Changes
* `nautical-backup.curl.before` --> `nautical-backup.exec.before`
* `nautical-backup.curl.after `--> `nautical-backup.exec.after`
* `nautical-backup.curl.during` --> `nautical-backup.exec.during`

### Breaking change
None, any previous `curl` request will be automatically converted to the new `exec` format. However, we still recommend changing to the new format because we will eventually remove the `curl` labels and environment variables. 


