### PR TITLE
Add `USE_CONTAINER_BACKUP_DATE`

### DIFF
--- a/app/backup.py
+++ b/app/backup.py
@@ -505,8 +505,6 @@ class NauticalBackup:
 
         return dest_dir
 
-        return base_dest_dir
-
     def _backup_additional_folders_standalone(self, when: BeforeOrAfter, base_dest_dir: Path):
         """Backup folders that are not associated with a container."""
         additional_folders = str(self.env.ADDITIONAL_FOLDERS)

--- a/app/backup.py
+++ b/app/backup.py
@@ -473,7 +473,7 @@ class NauticalBackup:
             time_format = str(self.start_time.strftime(self.env.DEST_DATE_FORMAT))
             if self.env.USE_CONTAINER_BACKUP_DATE:
                 # Use current time for formatting
-                self.log_this(f"Using current time for date formatting since DEST_DATE_FORMAT=true", "Trace")
+                self.log_this(f"Using current time for date formatting since USE_CONTAINER_BACKUP_DATE=true", "Trace")
                 time_format = str(time.strftime(self.env.DEST_DATE_FORMAT))
 
             if str(self.env.DEST_DATE_PATH_FORMAT) == "container/date":
@@ -495,7 +495,7 @@ class NauticalBackup:
         time_format = str(self.start_time.strftime(self.env.DEST_DATE_FORMAT))
         if self.env.USE_CONTAINER_BACKUP_DATE:
             # Use current time for formatting
-            self.log_this(f"Using current time for date formatting since DEST_DATE_FORMAT=true", "Trace")
+            self.log_this(f"Using current time for date formatting since USE_CONTAINER_BACKUP_DATE=true", "Trace")
             time_format = str(time.strftime(self.env.DEST_DATE_FORMAT))
 
         if str(self.env.DEST_DATE_PATH_FORMAT) == "container/date":

--- a/app/defaults.env
+++ b/app/defaults.env
@@ -23,6 +23,10 @@ DEST_DATE_PATH_FORMAT=date/container
 # Python Date format
 DEST_DATE_FORMAT=%Y-%m-%d
 
+# Use the precise date and time for fomatting the destination folder
+# Otherwise, use the time Nautical started the backup (not when the container was backed up)
+USE_CONTAINER_BACKUP_DATE=true
+
 # Use the default rsync args "-ahq" (archive, human-readable, quiet)
 USE_DEFAULT_RSYNC_ARGS=true
 

--- a/app/nautical_env.py
+++ b/app/nautical_env.py
@@ -37,9 +37,9 @@ class NauticalEnv:
         if self.DEST_DATE_PATH_FORMAT not in ["date/container", "container/date"]:
             self.DEST_DATE_PATH_FORMAT = "date/container"  # Set default
 
-        self.USE_CONTAINER_BACKUP_DATE = True
-        if os.environ.get("USE_CONTAINER_BACKUP_DATE", "true").lower() == "false":
-            self.USE_CONTAINER_BACKUP_DATE = False
+        self.USE_CONTAINER_BACKUP_DATE = False
+        if os.environ.get("USE_CONTAINER_BACKUP_DATE", "false").lower() == "true":
+            self.USE_CONTAINER_BACKUP_DATE = True
 
         # Not associated with containers
         self.ADDITIONAL_FOLDERS = os.environ.get("ADDITIONAL_FOLDERS", "")

--- a/app/nautical_env.py
+++ b/app/nautical_env.py
@@ -37,6 +37,10 @@ class NauticalEnv:
         if self.DEST_DATE_PATH_FORMAT not in ["date/container", "container/date"]:
             self.DEST_DATE_PATH_FORMAT = "date/container"  # Set default
 
+        self.USE_CONTAINER_BACKUP_DATE = True
+        if os.environ.get("USE_CONAINER_BACKUP_DATE", "true").lower() == "false":
+            self.USE_CONTAINER_BACKUP_DATE = False
+
         # Not associated with containers
         self.ADDITIONAL_FOLDERS = os.environ.get("ADDITIONAL_FOLDERS", "")
         self.ADDITIONAL_FOLDERS_WHEN = os.environ.get("ADDITIONAL_FOLDERS_WHEN", "before")

--- a/app/nautical_env.py
+++ b/app/nautical_env.py
@@ -38,7 +38,7 @@ class NauticalEnv:
             self.DEST_DATE_PATH_FORMAT = "date/container"  # Set default
 
         self.USE_CONTAINER_BACKUP_DATE = True
-        if os.environ.get("USE_CONAINER_BACKUP_DATE", "true").lower() == "false":
+        if os.environ.get("USE_CONTAINER_BACKUP_DATE", "true").lower() == "false":
             self.USE_CONTAINER_BACKUP_DATE = False
 
         # Not associated with containers

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -84,6 +84,41 @@ Use this option to designate which path strategy is used when creating a dated d
 DEST_DATE_PATH_FORMAT=date/container
 ```
 
+### Container Backup Date vs Nautical Start Date
+Use the precise date for fomatting the destination folder
+When `false`, use the time Nautical started the backup (not when the container was backed up).
+
+> **Default**: false
+
+```properties
+USE_CONTAINER_BACKUP_DATE=true
+```
+
+
+???+ example "Understanding `USE_CONTAINER_BACKUP_DATE`."
+    Let's say you have the following format: `DEST_DATE_FORMAT=%Y-%m-%d_%H-%M-%S`
+
+    Since the timing is so precise <small>(using seconds)</small> we may get a result like this:
+    ```python
+    -- src
+    |-- 2024-11-24_14-26-43
+    |-- 2024-11-24_14-26-44
+    |-- 2024-11-24_14-28-10
+    ```
+
+    But what we actually want is a result like this:
+    ```python
+    -- src
+    |-- 2024-11-24_14-26-43
+    #  (1)
+    |-- 2024-11-24_14-28-10
+    ```
+
+    1. The folder that was here is now within in `2024-11-24_14-26-43` folder
+
+    By setting `USE_CONTAINER_BACKUP_DATE=false`, then the date used will be the time Nautical actually started, not the time when each container is processed.
+    Meaning that even if the containers take a few minutes to backup, the folder format will remain the same for each of them.
+
 ## Additional Folders
 Allows Nautical to backup folders that are not associated with containers.
 

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -85,7 +85,7 @@ DEST_DATE_PATH_FORMAT=date/container
 ```
 
 ### Container Backup Date vs Nautical Start Date
-Use the precise date for fomatting the destination folder
+Use the precise date for formatting the destination folder
 When `false`, use the time Nautical started the backup (not when the container was backed up).
 
 > **Default**: false


### PR DESCRIPTION
Requested by https://github.com/Minituff/nautical-backup/issues/380

### Container Backup Date vs Nautical Start Date
Use the precise date for formatting the destination folder
When `false`, use the time Nautical started the backup (not when the container was backed up).

> **Default**: false

```properties
USE_CONTAINER_BACKUP_DATE=true
```


#### Understanding `USE_CONTAINER_BACKUP_DATE`.
Let's say you have the following format: `DEST_DATE_FORMAT=%Y-%m-%d_%H-%M-%S`

Since the timing is so precise <small>(using seconds)</small> we may get a result like this:
```python
-- src
|-- 2024-11-24_14-26-43
|-- 2024-11-24_14-26-44
|-- 2024-11-24_14-28-10
```

But what we actually want is a result like this:
```python
-- src
|-- 2024-11-24_14-26-43
#  The folder that was here is now within in `2024-11-24_14-26-43` folder
|-- 2024-11-24_14-28-10
```


By setting `USE_CONTAINER_BACKUP_DATE=false`, then the date used will be the time Nautical actually started, not the time when each container is processed.
Meaning that even if the containers take a few minutes to backup, the folder format will remain the same for each of them.
