### PR TITLE
Add stop timeout

### DIFF
--- a/app/backup.py
+++ b/app/backup.py
@@ -365,6 +365,9 @@ class NauticalBackup:
             self.log_this(f"Container {c.name} was not running. No need to stop.", "DEBUG")
             return True
 
+        stop_timeout = str(self.get_label(c, "stop_timeout", str(self.env.STOP_TIMEOUT)))
+        stop_timeout = int(stop_timeout)
+
         self.log_this(f"Stopping {c.name}...", "INFO")
         try:
             c.stop(timeout=10)  # * Actually stop the container

--- a/app/backup.py
+++ b/app/backup.py
@@ -365,12 +365,12 @@ class NauticalBackup:
             self.log_this(f"Container {c.name} was not running. No need to stop.", "DEBUG")
             return True
 
-        stop_timeout = str(self.get_label(c, "stop_timeout", str(self.env.STOP_TIMEOUT)))
+        stop_timeout = str(self.get_label(c, "stop-timeout", str(self.env.STOP_TIMEOUT)))
         stop_timeout = int(stop_timeout)
 
         self.log_this(f"Stopping {c.name}...", "INFO")
         try:
-            c.stop(timeout=10)  # * Actually stop the container
+            c.stop(timeout=stop_timeout)  # * Actually stop the container
         except APIError as e:
             self.log_this(f"Error stopping container {c.name}. Skipping backup for this container.", "ERROR")
             return False

--- a/app/defaults.env
+++ b/app/defaults.env
@@ -36,6 +36,9 @@ REQUIRE_LABEL=false
 # Label prefix
 LABEL_PREFIX=nautical-backup
 
+# How long to wait for a container to stop before killing it
+STOP_TIMEOUT=10
+
 # Set the default log level to INFO
 LOG_LEVEL=INFO
 

--- a/app/nautical_env.py
+++ b/app/nautical_env.py
@@ -68,6 +68,8 @@ class NauticalEnv:
         if os.environ.get("REPORT_FILE", "True").lower() == "false":
             self.REPORT_FILE = False
 
+        self.STOP_TIMEOUT = int(os.environ.get("STOP_TIMEOUT", 10))
+
     @staticmethod
     def _populate_override_dirs(env_name: str) -> Dict[str, str]:
         """Translate the Enviornment variable from single string to Python Dict.

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -406,6 +406,17 @@ SKIP_STOPPING=example1,example2
 
 <small>🔄 This is the same action as the [Stop Before Backup](./labels.md#stop-container-before-backup) label, but applied globally.</small>
 
+## Stop Timeout
+Nautical will allow the contianer *x* amount of _seconds_ to shutdown gracefully before killing the container.
+
+> **Default**: 10 <small>(seconds)</small>
+
+```properties
+STOP_TIMEOUT=10
+```
+
+<small>🔄 This is the same action as the [Stop Timeout](./labels.md#stop-timeout) label, but applied globally.</small>
+
 ## Backup on Start
 Nautical will immediately perform a backup when the container is started in addition to the CRON scheduled backup.
 

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -144,6 +144,17 @@ nautical-backup.stop-before-backup=false
 
 <small>🔄 This is a similar action to the [Skip Stopping Containers](./arguments.md#skip-stopping-containers) variable, but applied only to this container.</small>
 
+## Stop Timeout
+Nautical will allow the contianer *x* amount of _seconds_ to shutdown gracefully before killing the container.
+
+> **Default If Missing**: [Stop Timeout](./arguments.md#stop-timeout) Enviornemnt value<small> (Defaults to 10 seconds)</small>
+
+```properties
+nautical-backup.stop-timeout=10
+```
+
+<small>🔄 This is a similar action to the [Stop Timeout](./arguments.md#stop-timeout) variable, but applied only to this container.</small>
+
 ## Groups
 Use this label to have multiple containers stopped, backed up, and restarted at the same time.
 


### PR DESCRIPTION
## Stop Timeout Environment variable
Nautical will allow the container *x* amount of _seconds_ to shutdown gracefully before killing the container.

> **Default**: 10 <small>(seconds)</small>

```properties
STOP_TIMEOUT=10
```
## Stop Timeout Label

> **Default If Missing**: [Stop Timeout](./arguments.md#stop-timeout) Enviornemnt value<small> (Defaults to 10 seconds)</small>

```properties
nautical-backup.stop-timeout=10
```