### PR TITLE
Fix typo in docker tooltip snippet

### DIFF
--- a/snippets/docker-example-tooltips.md
+++ b/snippets/docker-example-tooltips.md
@@ -4,7 +4,7 @@
 4. *TIP*: Avoid using "quotes" in the enviornment variables.
 5. Scheduled time to run backups. Use [this website](https://crontab.guru) to help pick a CRON schedule.
     * Default = `0 4 * * *` - Every day at 4am.
-6. Containers to skip for backup. A comma seperated list.
+6. Containers to skip for backup. A comma-separated list.
 7. It is recommended to avoid using the `latest` tag.
     * This project is under active development, using a exact tag can help avoid updates breaking things.
 8. Set the time-zone. See this [Wikipedia page](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for a list of available time-zones.


### PR DESCRIPTION
## Summary
- fix typo in docker tooltip snippet: use "comma-separated list"

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'app')

------
https://chatgpt.com/codex/tasks/task_e_68a11a0413a88329bd2a6f4d0e663c60