### PR TITLE
Skip Nautical backup container by image or label

### DIFF
--- a/app/backup.py
+++ b/app/backup.py
@@ -133,8 +133,10 @@ class NauticalBackup:
 
         if "minituff/nautical-backup" in str(c.image):
             self.log_this(f"Skipping {c.name} {c.id} because it's image matches 'minituff/nautical-backup'.", "TRACE")
+            return True
         if c.labels.get("org.opencontainers.image.title") == "nautical-backup":
             self.log_this(f"Skipping {c.name} {c.id} because it's image matches 'nautical-backup'.", "TRACE")
+            return True
         if c.id == SELF_CONTAINER_ID:
             self.log_this(f"Skipping {c.name} {c.id} because it's ID is the same as Nautical", "TRACE")
             return True


### PR DESCRIPTION
## Summary
- return early when container image is `minituff/nautical-backup`
- return early when label `org.opencontainers.image.title` is `nautical-backup`

## Testing
- `PYTHONPATH=. pytest pytest/test_api.py pytest/test_db.py pytest/test_logger.py pytest/test_nautical_env.py pytest/test_rsync.py pytest/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a11a11aa708329a632361e7b245230