### PR TITLE
docs: clarify log level mapping comment

### DIFF
--- a/app/logger.py
+++ b/app/logger.py
@@ -52,7 +52,7 @@ class Logger:
         if isinstance(log_level, LogLevel):
             return log_level
 
-        # Override the defaults with environment variables if they exist
+        # Map a string log level to LogLevel, returning None for unknown values.
         if log_level.lower().strip() == "trace":
             return LogLevel.TRACE
         elif log_level.lower().strip() == "debug":


### PR DESCRIPTION
## Summary
- clarify comment explaining `_parse_log_level`

## Testing
- `PYTHONPATH=$PWD pytest` *(fails: OSError: [Errno 22] Invalid argument: '.')*

------
https://chatgpt.com/codex/tasks/task_e_68a11a1a1afc83299c890367d0c76bcd