### PR TITLE
feat: add SKIP_GROUPS environment variable to skip containers by group membership

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Config
+Please read the [AGENTS.md](../AGENTS.md) file for more information on how to configure Claude.
+@../AGENTS.md

--- a/app/backup.py
+++ b/app/backup.py
@@ -244,8 +244,29 @@ class NauticalBackup:
             self._record_container_skipped(c, "skip_containers_id", f"Skipping {c.name} based on ID {c.id}")
             return True
 
+        SKIP_GROUPS = self.env.SKIP_GROUPS
+        skip_groups_set = {g.strip() for g in SKIP_GROUPS.split(",") if g.strip()}
+        if skip_groups_set:
+            matched_groups = skip_groups_set.intersection(self._get_container_groups(c))
+            if matched_groups:
+                self._record_container_skipped(
+                    c,
+                    "skip_groups",
+                    f"Skipping {c.name} because it belongs to skipped group(s): {', '.join(sorted(matched_groups))}",
+                )
+                return True
+
         # No reason to skip
         return False
+
+    def _get_container_groups(self, c: Container) -> List[str]:
+        """Return the explicit groups a container belongs to via the `group` label.
+        Returns an empty list if the container has no group label (i.e. it is not
+        part of any user-defined group)."""
+        group = str(self.get_label(c, "group", "") or "")
+        if not group:
+            return []
+        return [g.strip() for g in group.split(",") if g.strip()]
 
     def group_containers(self) -> Dict[str, List[Container]]:
         containers: List[Container] = self.docker.containers.list()  # type: ignore
@@ -266,14 +287,12 @@ class NauticalBackup:
             if self._should_skip_container(c) == True:
                 continue  # Skip this container
 
-            # Create a default group, so ungrouped items are not grouped together
-            default_group = f"{self.default_group_pfx_sfx}{str(c.id)[0:12]}{self.default_group_pfx_sfx}"
-            group = str(self.get_label(c, "group", default_group))
-            if not group or group == "":
-                group = default_group
+            groups = self._get_container_groups(c)
+            if not groups:
+                # Create a default group, so ungrouped items are not grouped together
+                default_group = f"{self.default_group_pfx_sfx}{str(c.id)[0:12]}{self.default_group_pfx_sfx}"
+                groups = [default_group]
 
-            # Split the group string into a list of groups by comma
-            groups = group.split(",")
             for g in groups:
                 # Get priority. Default=100
                 priority = int(self.get_label(c, f"group.{g}.priority", 100))

--- a/app/defaults.env
+++ b/app/defaults.env
@@ -128,6 +128,9 @@ TARGETPLATFORM=""
 # Containers to be skipped completely. No backup
 SKIP_CONTAINERS=""
 
+# Containers belonging to these groups (see nautical-backup.group label) are skipped completely. No backup
+SKIP_GROUPS=""
+
 # Containers to still be backed up, but not stopped beforehand.
 SKIP_STOPPING=""
 

--- a/app/nautical_env.py
+++ b/app/nautical_env.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 class NauticalEnv:
     def __init__(self) -> None:
         self.SKIP_CONTAINERS = os.environ.get("SKIP_CONTAINERS", "")
+        self.SKIP_GROUPS = os.environ.get("SKIP_GROUPS", "")
         self.SKIP_STOPPING = os.environ.get("SKIP_STOPPING", "")
         self.SELF_CONTAINER_ID = os.environ.get("SELF_CONTAINER_ID", "")
 

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -393,6 +393,22 @@ This list can either be the container `name` or full `id`.
 
 <small>🔄 This is the same action as the [Disable Nautical](./labels.md#enable-or-disable-nautical) label, but applied globally.</small>
 
+## Skip Groups
+Tell Nautical to skip backup of every container belonging to any of these [Groups](./labels.md#groups).
+
+A container is skipped if it belongs to *any* group in this list, even if it also belongs to other groups that are not listed.
+
+> **Default**: *empty* <small>(no skips)</small>
+
+```properties
+SKIP_GROUPS=group1,group2
+```
+
+!!! tip "Automatically applies to new containers"
+    Group membership is re-checked on every backup run, so adding a new container to an already-skipped group is enough &mdash; there's no need to update this list.
+
+<small>Only containers with an explicit [`nautical-backup.group`](./labels.md#groups) label can match. This can be combined with [Skip Containers](#skip-containers); a container is skipped if it matches either list.</small>
+
 ## Require Label
 Require the Docker ^^Label^^ `nautical-backup.enable=true` to be present on *each* container or it will be skipped.
 

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -222,6 +222,7 @@ nautical-backup.group=group_name
               - "nautical-backup.group=authentic"
         ```
 
+<small>🔄 Want to skip every container in a group instead? See [Skip Groups](./arguments.md#skip-groups).</small>
 
 ## Group Priority (Order)
 When using the [Groups](#groups) feature, the Priority will allow you to control the order in which containers are started/stopped.

--- a/pytest/test_backup.py
+++ b/pytest/test_backup.py
@@ -352,6 +352,131 @@ class TestBackup:
     @mock.patch("subprocess.run")
     @pytest.mark.parametrize(
         "mock_container1",
+        [{"name": "container1", "id": "123456789", "labels": {"nautical-backup.group": "paperless"}}],
+        indirect=True,
+    )
+    @pytest.mark.parametrize(
+        "mock_container2",
+        [{"name": "container2", "id": "9876543210", "labels": {"nautical-backup.group": "authentic"}}],
+        indirect=True,
+    )
+    @pytest.mark.parametrize("mock_container3", [{"name": "container3", "id": "6969696969"}], indirect=True)
+    def test_skip_groups_env(
+        self,
+        mock_subprocess_run: MagicMock,
+        mock_docker_client: MagicMock,
+        mock_container1: MagicMock,
+        mock_container2: MagicMock,
+        mock_container3: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """SKIP_GROUPS should skip every container in a matching group, and leave others alone"""
+        mock_subprocess_run.return_value.returncode = 0
+
+        monkeypatch.setenv("SKIP_GROUPS", "paperless")
+
+        mock_docker_client.containers.list.return_value = [mock_container1, mock_container2, mock_container3]
+        nb = NauticalBackup(mock_docker_client)
+        nb.backup()
+
+        # Container1 is in the "paperless" group, which is skipped
+        mock_container1.stop.assert_not_called()
+        mock_container1.start.assert_not_called()
+        assert "container1" in nb.containers_skipped
+        assert nb.container_skip_reasons["container1"] == "skip_groups"
+
+        # Container2 is in a different group ("authentic"), and container3 has no group at all.
+        # Neither should be affected by SKIP_GROUPS=paperless
+        mock_container2.stop.assert_called()
+        mock_container2.start.assert_called()
+        mock_container3.stop.assert_called()
+        mock_container3.start.assert_called()
+        assert "container2" not in nb.containers_skipped
+        assert "container3" not in nb.containers_skipped
+
+        # Rsync should only be called for container2 and container3
+        assert mock_subprocess_run.call_count == 2
+
+    @mock.patch("subprocess.run")
+    @pytest.mark.parametrize(
+        "mock_container1",
+        [{"name": "container1", "id": "123456789", "labels": {"nautical-backup.group": "authentic,paperless"}}],
+        indirect=True,
+    )
+    def test_skip_groups_env_any_match_across_multiple_groups(
+        self,
+        mock_subprocess_run: MagicMock,
+        mock_docker_client: MagicMock,
+        mock_container1: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A container belonging to multiple groups is skipped if any one of them is in SKIP_GROUPS"""
+        mock_subprocess_run.return_value.returncode = 0
+
+        monkeypatch.setenv("SKIP_GROUPS", "paperless")
+
+        mock_docker_client.containers.list.return_value = [mock_container1]
+        nb = NauticalBackup(mock_docker_client)
+        nb.backup()
+
+        mock_container1.stop.assert_not_called()
+        mock_container1.start.assert_not_called()
+        assert "container1" in nb.containers_skipped
+        assert mock_subprocess_run.call_count == 0
+
+    @mock.patch("subprocess.run")
+    @pytest.mark.parametrize(
+        "mock_container1",
+        [{"name": "container1", "id": "123456789", "labels": {"nautical-backup.group": "paperless"}}],
+        indirect=True,
+    )
+    @pytest.mark.parametrize("mock_container2", [{"name": "container2", "id": "9876543210"}], indirect=True)
+    @pytest.mark.parametrize(
+        "mock_container3",
+        [{"name": "container3", "id": "6969696969", "labels": {"nautical-backup.group": "authentic"}}],
+        indirect=True,
+    )
+    def test_skip_containers_and_skip_groups_combined(
+        self,
+        mock_subprocess_run: MagicMock,
+        mock_docker_client: MagicMock,
+        mock_container1: MagicMock,
+        mock_container2: MagicMock,
+        mock_container3: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """SKIP_CONTAINERS and SKIP_GROUPS are additive and never double-skip a container"""
+        mock_subprocess_run.return_value.returncode = 0
+
+        # container1 matches both SKIP_CONTAINERS (by name) and SKIP_GROUPS (via its group)
+        monkeypatch.setenv("SKIP_CONTAINERS", "container1")
+        monkeypatch.setenv("SKIP_GROUPS", "paperless")
+
+        mock_docker_client.containers.list.return_value = [mock_container1, mock_container2, mock_container3]
+        nb = NauticalBackup(mock_docker_client)
+        nb.backup()
+
+        # container1 matches both lists but is only skipped/recorded once
+        mock_container1.stop.assert_not_called()
+        mock_container1.start.assert_not_called()
+        assert list(nb.containers_skipped).count("container1") == 1
+        assert nb.container_skip_reasons["container1"] == "skip_containers_name"
+
+        # container2 matches neither list
+        mock_container2.stop.assert_called()
+        mock_container2.start.assert_called()
+        assert "container2" not in nb.containers_skipped
+
+        # container3 is in a different group, not affected by SKIP_GROUPS=paperless
+        mock_container3.stop.assert_called()
+        mock_container3.start.assert_called()
+        assert "container3" not in nb.containers_skipped
+
+        assert mock_subprocess_run.call_count == 2
+
+    @mock.patch("subprocess.run")
+    @pytest.mark.parametrize(
+        "mock_container1",
         [{"name": "container1", "id": "123456789", "labels": {"nautical-backup.enable": "false"}}],
         indirect=True,
     )

--- a/pytest/test_nautical_env.py
+++ b/pytest/test_nautical_env.py
@@ -31,3 +31,14 @@ class TestNauticalEnv:
 
         assert "example3" in nautical_env.OVERRIDE_DEST_DIR
         assert "fake" not in nautical_env.OVERRIDE_DEST_DIR
+
+    def test_skip_groups_default(self):
+        """SKIP_GROUPS defaults to an empty string when unset"""
+        nautical_env = NauticalEnv()
+        assert nautical_env.SKIP_GROUPS == ""
+
+    def test_skip_groups_env(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("SKIP_GROUPS", "group1,group2")
+        nautical_env = NauticalEnv()
+
+        assert nautical_env.SKIP_GROUPS == "group1,group2"


### PR DESCRIPTION
- Implemented SKIP_GROUPS in NauticalBackup to allow skipping containers based on their group labels.
- Updated defaults.env to include SKIP_GROUPS variable.
- Enhanced documentation to explain the usage of SKIP_GROUPS.
- Added tests to verify the functionality of SKIP_GROUPS.