### PR TITLE
feat: allow customization of report file name prefix with support for tokens

### DIFF
--- a/app/defaults.env
+++ b/app/defaults.env
@@ -63,6 +63,11 @@ REPORT_FILE_LOG_LEVEL=INFO
 # Only write to the report file when backups run, not on initialization
 REPORT_FILE_ON_BACKUP_ONLY=true
 
+# Customize the report file's name prefix (e.g. "server-1-backup"). The date is
+# always appended. Supports {label_prefix}/{LABEL_PREFIX}/{prefix}/{PREFIX} tokens,
+# substituted with LABEL_PREFIX. Defaults to "Backup Report".
+REPORT_FILE_NAME=""
+
 # Mirror the source directory name to the destination directory name
 KEEP_SRC_DIR_NAME=true
 

--- a/app/logger.py
+++ b/app/logger.py
@@ -20,6 +20,11 @@ class LogType(Enum):
 
 
 class Logger:
+    DEFAULT_REPORT_FILE_PREFIX = "Backup Report"
+    # All of these are treated as equivalent placeholders for LABEL_PREFIX,
+    # so users can use whichever spelling reads naturally in REPORT_FILE_NAME.
+    PREFIX_TOKENS = ("{label_prefix}", "{LABEL_PREFIX}", "{prefix}", "{PREFIX}")
+
     def __init__(self):
         self.levels = {LogLevel.TRACE: 0, LogLevel.DEBUG: 1, LogLevel.INFO: 2, LogLevel.WARN: 3, LogLevel.ERROR: 4}
         self.env = NauticalEnv()
@@ -40,7 +45,8 @@ class Logger:
             self.report_file_on_backup_only = False
 
         self.dest_location: Union[str, Path] = os.environ.get("DEST_LOCATION", "")
-        self.report_file = f"Backup Report - {datetime.datetime.now().strftime('%Y-%m-%d')}.txt"
+        self.report_file_prefix = self._resolve_report_file_prefix(self.env.REPORT_FILE_NAME)
+        self.report_file = f"{self.report_file_prefix} - {datetime.datetime.now().strftime('%Y-%m-%d')}.txt"
 
     @staticmethod
     def set_to_string(input: set) -> str:
@@ -65,14 +71,37 @@ class Logger:
             return LogLevel.ERROR
         return None
 
+    def _resolve_report_file_prefix(self, report_file_name: str) -> str:
+        """Turn REPORT_FILE_NAME into a safe report file prefix.
+
+        Falls back to the default prefix (and warns) if REPORT_FILE_NAME is unset,
+        or if it would escape dest_location via a path separator or "..".
+        """
+        prefix = report_file_name.strip()
+        if not prefix:
+            return self.DEFAULT_REPORT_FILE_PREFIX
+
+        for token in self.PREFIX_TOKENS:
+            prefix = prefix.replace(token, self.env.LABEL_PREFIX)
+
+        if "/" in prefix or "\\" in prefix or ".." in prefix:
+            print(
+                f"WARN: Invalid REPORT_FILE_NAME '{report_file_name}' (must not contain "
+                f"'/', '\\', or '..'); falling back to the default report file name."
+            )
+            return self.DEFAULT_REPORT_FILE_PREFIX
+
+        return prefix
+
     def _delete_old_report_files(self):
         """Only completed on Nautical init"""
         if not os.path.exists(self.dest_location):
             return
 
+        prefix = f"{self.report_file_prefix} - "
         for file in os.listdir(self.dest_location):
             file.strip()
-            if file.startswith("Backup Report -") and file.endswith(".txt"):
+            if file.startswith(prefix) and file.endswith(".txt"):
                 if file != self.report_file:
                     # Don't delete today's report file
                     os.remove(os.path.join(self.dest_location, file))
@@ -86,7 +115,7 @@ class Logger:
 
         # Initialize the current report file with a header
         with open(os.path.join(self.dest_location, self.report_file), "w+") as f:
-            f.write(f"Backup Report - {datetime.datetime.now()}\n")
+            f.write(f"{self.report_file_prefix} - {datetime.datetime.now()}\n")
 
     def _write_to_report_file(self, log_message, log_level: Union[str, LogLevel] = LogLevel.INFO):
         level = self._parse_log_level(log_level)

--- a/app/logger.sh
+++ b/app/logger.sh
@@ -25,17 +25,36 @@ if [ ! -z "$REPORT_FILE_ON_BACKUP_ONLY" ]; then
     report_file_on_backup_only=$REPORT_FILE_ON_BACKUP_ONLY
 fi
 
-report_file="Backup Report - $(date +'%Y-%m-%d').txt"
+# Resolve REPORT_FILE_NAME into a report file prefix, mirroring logger.py's
+# _resolve_report_file_prefix(). {label_prefix}/{LABEL_PREFIX}/{prefix}/{PREFIX}
+# are all equivalent placeholders for LABEL_PREFIX.
+report_file_prefix="Backup Report"
+if [ ! -z "$REPORT_FILE_NAME" ]; then
+    report_file_prefix="$REPORT_FILE_NAME"
+    report_file_prefix="${report_file_prefix//\{label_prefix\}/$LABEL_PREFIX}"
+    report_file_prefix="${report_file_prefix//\{LABEL_PREFIX\}/$LABEL_PREFIX}"
+    report_file_prefix="${report_file_prefix//\{prefix\}/$LABEL_PREFIX}"
+    report_file_prefix="${report_file_prefix//\{PREFIX\}/$LABEL_PREFIX}"
+
+    case "$report_file_prefix" in
+        */*|*'\'*|*'..'*)
+            echo "WARN: Invalid REPORT_FILE_NAME '$REPORT_FILE_NAME' (must not contain '/', '\\', or '..'); falling back to the default report file name."
+            report_file_prefix="Backup Report"
+            ;;
+    esac
+fi
+
+report_file="$report_file_prefix - $(date +'%Y-%m-%d').txt"
 
 delete_report_file() {
-    rm -f "$DEST_LOCATION/Backup Report - "*.txt
+    rm -f "$DEST_LOCATION/$report_file_prefix - "*.txt
 }
 
 create_new_report_file() {
     if [ "$REPORT_FILE" = "true" ]; then
         delete_report_file
         # Initialize the current report file with a header
-        echo "Backup Report - $(date)" >"$DEST_LOCATION/$report_file"
+        echo "$report_file_prefix - $(date)" >"$DEST_LOCATION/$report_file"
     fi
 }
 

--- a/app/nautical_env.py
+++ b/app/nautical_env.py
@@ -13,6 +13,7 @@ class NauticalEnv:
         self.LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
         self.REPORT_FILE_LOG_LEVEL = os.environ.get("REPORT_FILE_LOG_LEVEL", "")
         self.REPORT_FILE_ON_BACKUP_ONLY = os.environ.get("REPORT_FILE_ON_BACKUP_ONLY", "")
+        self.REPORT_FILE_NAME = os.environ.get("REPORT_FILE_NAME", "")
 
         self.DEST_LOCATION = os.environ.get("DEST_LOCATION", "")
         self.SOURCE_LOCATION = os.environ.get("SOURCE_LOCATION", "")

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -420,32 +420,6 @@ REQUIRE_LABEL=true
 
 See the [Enable or Disable Nautical](./labels.md#enable-or-disable-nautical) Label Section for more details.
 
-## Multi-Instance Label Prefix
-Sometimes, running multiple insances of nautical-backup can enable extra funcunality: such as unique CRON schedules for different containers, etc.
-
-By default, nautical-backup will only scan containers having labels starting with `nautical-backup.*`. To be able to run multiple instances of nautical-backup, you may want to customize the label prefix to avoid colision among instances.
-
-> **Default**: nautical-backup
-
-```yaml
-services:
-  # Multiple instance of nautical
-  nautical-inst1:
-    environment:
-      - LABEL_PREFIX=nautical-backup.inst1
-  nautical-inst2:
-    environment:
-      - LABEL_PREFIX=nautical-backup.inst2
-
-  # Multi targets
-  backuped-inst1:
-    labels:
-      - nautical-backup.inst1.enable=true
-  backuped-inst2:
-    labels:
-      - nautical-backup.inst2.enable=true
-```
-
 ## Override Source Directory
 Allows a source directory and container-name that do not match.
 
@@ -548,15 +522,6 @@ POST_BACKUP_EXEC=curl -d "Backup successful 😀" ntfy.sh/mytopic
     ```
 
 <small>🔄 This is the same action as the [Execute Commands](./labels.md#execute-commands) label, but applied globally (not per container).</small>
-
-## Report file
-Enable or Disable the automatically generated report file.
-
-> **Default**: true
-
-```properties
-REPORT_FILE=true
-```
 
 ## Skip Stopping Containers
 Bypass stopping the container before performing a backup. This can be useful for containers with minimal configuration.
@@ -721,6 +686,20 @@ LOG_LEVEL=INFO
 
 Skipped containers are logged at `WARN`. Backup failures, such as rsync failures or containers that cannot be stopped or started, are logged at `ERROR`.
 
+## Report file
+Enable or Disable the automatically generated report file.
+
+> **Default**: true
+
+```properties
+REPORT_FILE=true
+```
+
+See [Report File Name](#report-file-name) to customize the report's filename —
+particularly useful when running [multiple Nautical instances](#multi-instance-label-prefix)
+against the same `DEST_LOCATION`.
+
+
 ## Report Log Level
 Set the log level for the generated report file.
 Only used if the report file is [enabled](#report-file).
@@ -743,6 +722,79 @@ With a value of `false`, then all logs will also be sent to the report file assu
 ```properties
 REPORT_FILE_ON_BACKUP_ONLY=false
 ```
+
+## Multi-Instance Label Prefix
+Sometimes, running multiple insances of nautical-backup can enable extra funcunality: such as unique CRON schedules for different containers, etc.
+
+By default, nautical-backup will only scan containers having labels starting with `nautical-backup.*`. To be able to run multiple instances of nautical-backup, you may want to customize the label prefix to avoid colision among instances.
+
+> **Default**: nautical-backup
+
+!!! tip "Also set `REPORT_FILE_NAME` when running multiple instances"
+    Instances sharing a `DEST_LOCATION` also share one [report file](#report-file), so
+    the last one to run overwrites the others. Set [`REPORT_FILE_NAME={PREFIX}`](#report-file-name)
+    alongside `LABEL_PREFIX` on each instance, as shown below, to fix this.
+
+```yaml
+services:
+  # Multiple instance of nautical
+  nautical-inst1:
+    environment:
+      - LABEL_PREFIX=nautical-backup.inst1
+      - REPORT_FILE_NAME={PREFIX}
+  nautical-inst2:
+    environment:
+      - LABEL_PREFIX=nautical-backup.inst2
+      - REPORT_FILE_NAME={PREFIX}
+
+  # Multi targets
+  backuped-inst1:
+    labels:
+      - nautical-backup.inst1.enable=true
+  backuped-inst2:
+    labels:
+      - nautical-backup.inst2.enable=true
+```
+
+## Report File Name
+Customize the prefix used for the report file's name. The date is always appended
+(the report file is always named `<prefix> - YYYY-MM-DD.txt`), so this only changes
+the prefix — it will not disable daily-dated report files.
+
+This is most useful when running [multiple Nautical instances](#multi-instance-label-prefix)
+against the same `DEST_LOCATION`: by default, every instance writes to the same
+`Backup Report - YYYY-MM-DD.txt`, so whichever instance runs last silently overwrites
+the others' report. Giving each instance a distinct `REPORT_FILE_NAME` avoids this.
+
+> **Default**: `Backup Report`
+
+> **Tokens**: `{label_prefix}`, `{LABEL_PREFIX}`, `{prefix}`, and `{PREFIX}` are all
+> equivalent, and are replaced with the instance's [`LABEL_PREFIX`](#multi-instance-label-prefix)
+> value — a convenient way to reuse an identifier you're already setting per instance.
+
+=== "Example 1"
+    !!! note ""
+        ```properties
+        LABEL_PREFIX=nautical-backup.inst1
+        REPORT_FILE_NAME={PREFIX}
+        ```
+
+        The `{PREFIX}` token is replaced with `LABEL_PREFIX`, so the report file
+        will be named `nautical-backup.inst1 - 2024-04-05.txt` — useful for
+        [multiple instances](#multi-instance-label-prefix) sharing one `DEST_LOCATION`.
+
+=== "Example 2"
+    !!! note ""
+        ```properties
+        REPORT_FILE_NAME=server-1-backup
+        ```
+
+        A plain literal prefix. The report file will be named
+        `server-1-backup - 2024-04-05.txt`.
+
+!!! warning "`/`, `\` and `..` are not allowed and will cause Nautical to fall back to the default `Backup Report` prefix."
+
+<small>ℹ️ This setting is unrelated to [`DEST_DATE_FORMAT`](#destination-folder-format), which only controls destination folder naming, not the report file.</small>
 
 ## Use Default rsync Arguments
 

--- a/pytest/test_logger.py
+++ b/pytest/test_logger.py
@@ -47,6 +47,59 @@ class TestLogger:
         rf = f"Backup Report - {datetime.now().strftime('%Y-%m-%d')}.txt"
         assert logger.report_file == rf
 
+    def test_report_file_name_default_unchanged(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("REPORT_FILE_NAME", raising=False)
+
+        logger = Logger()
+        expected = f"Backup Report - {datetime.now().strftime('%Y-%m-%d')}.txt"
+        assert logger.report_file_prefix == "Backup Report"
+        assert logger.report_file == expected
+
+    def test_report_file_name_custom_literal_prefix(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("REPORT_FILE_NAME", "server-1-backup")
+
+        logger = Logger()
+        expected = f"server-1-backup - {datetime.now().strftime('%Y-%m-%d')}.txt"
+        assert logger.report_file_prefix == "server-1-backup"
+        assert logger.report_file == expected
+
+    @pytest.mark.parametrize("token", ["{label_prefix}", "{LABEL_PREFIX}", "{prefix}", "{PREFIX}"])
+    def test_report_file_name_prefix_tokens(self, monkeypatch: pytest.MonkeyPatch, token: str):
+        monkeypatch.setenv("LABEL_PREFIX", "nautical-backup.inst1")
+        monkeypatch.setenv("REPORT_FILE_NAME", token)
+
+        logger = Logger()
+        expected = f"nautical-backup.inst1 - {datetime.now().strftime('%Y-%m-%d')}.txt"
+        assert logger.report_file_prefix == "nautical-backup.inst1"
+        assert logger.report_file == expected
+
+    def test_report_file_name_rejects_path_traversal(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ):
+        monkeypatch.setenv("REPORT_FILE_NAME", "../../etc/passwd")
+
+        logger = Logger()
+        assert logger.report_file_prefix == "Backup Report"
+        assert "Invalid REPORT_FILE_NAME" in capsys.readouterr().out
+
+    def test_report_file_name_prune_custom_prefix(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("REPORT_FILE_NAME", "inst1-report")
+
+        today_file = f"inst1-report - {datetime.now().strftime('%Y-%m-%d')}.txt"
+        (tmp_path / "inst1-report - 2024-01-01.txt").touch()
+        (tmp_path / "inst1-report - 2025-01-01.txt").touch()
+        (tmp_path / today_file).touch()
+        # A different instance's report files must not be touched
+        (tmp_path / "Backup Report - 2024-01-01.txt").touch()
+
+        logger = Logger()
+        logger.dest_location = tmp_path
+
+        logger._delete_old_report_files()
+
+        files = {f.name for f in tmp_path.iterdir()}
+        assert files == {today_file, "Backup Report - 2024-01-01.txt"}
+
     @patch("builtins.open", new_callable=MagicMock)
     def test_create_report_file(self, mock_open: MagicMock, tmp_path: Path):
         logger = Logger()

--- a/tests/_integration_tests.sh
+++ b/tests/_integration_tests.sh
@@ -286,6 +286,7 @@ declare -A expected_env_vars=(
     ["LOG_LEVEL"]="INFO"
     ["REPORT_FILE_LOG_LEVEL"]="INFO"
     ["REPORT_FILE_ON_BACKUP_ONLY"]="true"
+    ["REPORT_FILE_NAME"]=""
     ["KEEP_SRC_DIR_NAME"]="true"
     ["EXIT_AFTER_INIT"]="false"
     ["LOG_RSYNC_COMMANDS"]="false"


### PR DESCRIPTION
## Report File Name
Customize the prefix used for the report file's name. The date is always appended (the report file is always named `<prefix> - YYYY-MM-DD.txt`), so this only changes the prefix — it will not disable daily-dated report files.

This is most useful when running multiple Nautical instances against the same `DEST_LOCATION`: by default, every instance writes to the same `Backup Report - YYYY-MM-DD.txt`, so whichever instance runs last silently overwrites the others' report. Giving each instance a distinct `REPORT_FILE_NAME` avoids this.

> **Default**: `Backup Report`

> **Tokens**: `{label_prefix}`, `{LABEL_PREFIX}`, `{prefix}`, and `{PREFIX}` are all
> equivalent, and are replaced with the instance's [`LABEL_PREFIX`](#multi-instance-label-prefix)
> value — a convenient way to reuse an identifier you're already setting per instance.

### Example 1

```properties
LABEL_PREFIX=nautical-backup.inst1
REPORT_FILE_NAME={PREFIX}
```

The `{PREFIX}` token is replaced with `LABEL_PREFIX`, so the report file will be named `nautical-backup.inst1 - 2024-04-05.txt` — useful for multiple instances sharing one `DEST_LOCATION`.

### Example 2

```properties
REPORT_FILE_NAME=server-1-backup
```
A plain literal prefix. The report file will be named `server-1-backup - 2024-04-05.txt`.

